### PR TITLE
Remove unneeded auth_tag

### DIFF
--- a/bin/orbis-node/src/store_secret/tests.rs
+++ b/bin/orbis-node/src/store_secret/tests.rs
@@ -367,7 +367,6 @@ async fn test_store_secret_fails_invalid_encryption_proof() {
         enc_cmt: enc_cmt_bytes.clone(),
         encrypted_data: vec![0u8; 32],
         nonce: vec![0u8; 12], // 12 bytes for AES-GCM
-        auth_tag: vec![0u8; 16],
     };
     let encrypted_doc = serde_json::to_string(&secret).expect("serialize Secret");
     let enc_cmt_hex = hex::encode(&enc_cmt_bytes);

--- a/crates/crypto/README.md
+++ b/crates/crypto/README.md
@@ -168,7 +168,6 @@ pub struct Secret {
     pub enc_cmt: Vec<u8>,        // rG - Schnorr commitment
     pub encrypted_data: Vec<u8>, // AES-GCM encrypted data
     pub nonce: Vec<u8>,          // AES-GCM nonce
-    pub auth_tag: Vec<u8>,       // Authentication tag
 }
 
 /// Re-encryption reply with NIZK proof

--- a/crates/crypto/src/bls12_381/pre.rs
+++ b/crates/crypto/src/bls12_381/pre.rs
@@ -242,7 +242,6 @@ impl ThresholdDealer for ThresholdDealerNode {
                 enc_cmt: enc_cmt_bytes,
                 encrypted_data: ciphertext,
                 nonce: nonce_bytes.to_vec(),
-                auth_tag: Vec::new(), // Included in ciphertext with AES-GCM
             },
             proof,
         ))

--- a/crates/crypto/src/trait.rs
+++ b/crates/crypto/src/trait.rs
@@ -66,7 +66,6 @@ pub struct Secret {
     pub enc_cmt: Vec<u8>,        // rG - Schnorr commitment
     pub encrypted_data: Vec<u8>, // AES-GCM encrypted data
     pub nonce: Vec<u8>,          // AES-GCM nonce (12 bytes)
-    pub auth_tag: Vec<u8>,       // Authentication tag
 }
 
 /// Chaum-Pedersen NIZK proof that encryption was performed correctly.


### PR DESCRIPTION
This is handled in  aes_gcm crate's Aes256Gcm::encrypt(), it appends the 16-byte auth tag to the ciphertext