### PR TITLE
Add utility services, CLI parameterization, and ACP enforcement

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,17 +10,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - features: "bls12-381,redb,integration-test,fault-injection"
+            label: bls12-381
+          - features: "decaf377,redb,integration-test,fault-injection"
+            label: decaf377
+
+    name: build-test (${{ matrix.label }})
 
     steps:
     - uses: actions/checkout@v4
+
+    - name: Free disk space
+      run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+
     - name: Install protoc
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: "v0-rust-${{ matrix.label }}"
+
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --no-default-features --features=${{ matrix.features }} --verbose
+
     - name: Run tests
-      run: cargo test --features=integration-test,fault-injection --verbose
-    - name: Run tests decaf377
-      run: cargo test --no-default-features --features=decaf377,redb,integration-test,fault-injection --verbose
+      run: cargo test --no-default-features --features=${{ matrix.features }} --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ public_key.txt
 
 # Claude Code local task tracking
 tasks/
+
+# Local agent context
+CLAUDE.md
+SESSION-PROMPT.md
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 4
 
 [[package]]
+name = "acp-light-client"
+version = "0.1.0"
+source = "git+https://github.com/sourcenetwork/backbone.git?branch=main#5cfa9e1206471e191248287561d80c27de17e530"
+dependencies = [
+ "alloy-primitives",
+ "borsh",
+ "commonware-codec",
+ "commonware-consensus",
+ "commonware-cryptography",
+ "eyre",
+ "futures",
+ "hex",
+ "jmt",
+ "parking_lot",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -74,6 +100,409 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy-consensus"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8222b1d88f9a6d03be84b0f5e76bb60cd83991b43ad8ab6477f0e4a7809b98d"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.1.1",
+ "foldhash",
+ "hashbrown 0.16.1",
+ "indexmap 2.12.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.2",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve 0.13.8",
+ "k256",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.12.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.111",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
 
 [[package]]
 name = "android_system_properties"
@@ -165,8 +594,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -176,9 +605,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
  "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -188,11 +617,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-relations",
- "ark-serialize",
+ "ark-serialize 0.4.2",
  "ark-snark",
- "ark-std",
+ "ark-std 0.4.0",
  "blake2",
  "derivative",
  "digest 0.10.7",
@@ -205,10 +634,10 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
  "itertools 0.10.5",
@@ -224,8 +653,26 @@ checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
  "ark-bls12-377",
  "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -234,18 +681,48 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
  "num-bigint",
  "num-traits",
  "paste",
- "rustc_version",
+ "rustc_version 0.4.1",
  "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -254,6 +731,28 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
  "quote",
  "syn 1.0.109",
 ]
@@ -272,6 +771,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "ark-groth16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,11 +791,11 @@ checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-poly",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
 ]
 
 [[package]]
@@ -292,9 +804,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
 dependencies = [
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "derivative",
  "hashbrown 0.13.2",
 ]
@@ -306,9 +818,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de1d1472e5cb020cb3405ce2567c91c8d43f21b674aef37b0202f5c3304761db"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-relations",
- "ark-std",
+ "ark-std 0.4.0",
  "derivative",
  "num-bigint",
  "num-integer",
@@ -322,10 +834,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
 dependencies = [
- "ark-ff",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
  "tracing",
  "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -335,7 +857,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std",
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -357,10 +891,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
 dependencies = [
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -368,6 +912,16 @@ name = "ark-std"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
@@ -384,6 +938,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "async-compat"
@@ -445,7 +1002,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "tungstenite",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -456,7 +1013,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -514,10 +1071,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -554,10 +1145,13 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.5",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -565,10 +1159,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "tokio",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -607,6 +1206,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -710,10 +1310,41 @@ dependencies = [
  "pbkdf2",
  "rand_core 0.6.4",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.27.0",
  "sha2 0.10.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -771,6 +1402,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
+ "zeroize",
 ]
 
 [[package]]
@@ -819,6 +1451,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,10 +1504,19 @@ dependencies = [
 name = "bulletin"
 version = "0.0.1"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
  "async-trait",
  "backoff",
+ "base64 0.22.1",
  "common",
  "hex",
+ "k256",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serial_test",
@@ -854,6 +1530,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -871,6 +1553,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1580,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -906,6 +1605,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher 0.4.4",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bd162f2b8af3e0639d83f28a637e4e55657b7a74508dba5a9bf4da523d5c9e9"
@@ -913,6 +1623,19 @@ dependencies = [
  "cfg-if",
  "cipher 0.5.0-rc.1",
  "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead 0.5.2",
+ "chacha20 0.9.1",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -925,7 +1648,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -963,6 +1686,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout 0.1.4",
+ "zeroize",
 ]
 
 [[package]]
@@ -1041,6 +1765,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+
+[[package]]
 name = "coarsetime"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1841,340 @@ dependencies = [
 ]
 
 [[package]]
+name = "commonware-broadcast"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b67e4fed57f8d77c8d92b7bdd7512aee03d9d27ce4c0d3d8f93dd50358e9efc"
+dependencies = [
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-utils",
+ "prometheus-client",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-codec"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af69c7b97ba7225a934e29fad444f35b5d365322efaaf724e1af66c99c8c6c3"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-macros",
+ "paste",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "commonware-coding"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b7b9371af121e60f7bb3f28ff891f03ba5f9b51cc22053994007d3083c30b"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-storage",
+ "commonware-utils",
+ "num-rational",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "reed-solomon-simd",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "commonware-consensus"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bdbc3361f501adce253ff92e652a997758e57c1e6298a4bc06836952b66b0c"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-broadcast",
+ "commonware-codec",
+ "commonware-coding",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-p2p",
+ "commonware-parallel",
+ "commonware-resolver",
+ "commonware-runtime",
+ "commonware-storage",
+ "commonware-utils",
+ "futures",
+ "pin-project",
+ "prometheus-client",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_distr",
+ "rayon",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-cryptography"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf9bba8bf1ad51f54c57bee0824987bb397bedb60a09917d6a93509828a2dff"
+dependencies = [
+ "anyhow",
+ "aws-lc-rs",
+ "blake3",
+ "blst",
+ "bytes",
+ "cfg-if",
+ "chacha20poly1305",
+ "commonware-codec",
+ "commonware-macros",
+ "commonware-math",
+ "commonware-parallel",
+ "commonware-utils",
+ "crc-fast",
+ "ctutils",
+ "ecdsa 0.16.9",
+ "ed25519-consensus",
+ "getrandom 0.2.16",
+ "num-rational",
+ "num-traits",
+ "p256 0.13.2",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "thiserror 2.0.17",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-macros"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8da60f9fe8357927327729fa7838b44555f4c578e4b07c12a2964664230a98"
+dependencies = [
+ "commonware-macros-impl",
+ "tokio",
+]
+
+[[package]]
+name = "commonware-macros-impl"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c4e1e7a838cff536ffbe38f441c555eee99322d755aed3e06af9407c127fd3"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "commonware-math"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a44f73b02286843967888c7aa750a7a91a5cd3ac8b9bc48cd1d81331836bbb"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-utils",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "commonware-p2p"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493b3ff98ef12a54162d9eae90175a6ff56e12df90f7b3381eff3cea84a8deb"
+dependencies = [
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-runtime",
+ "commonware-stream",
+ "commonware-utils",
+ "either",
+ "futures",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "prometheus-client",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_distr",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-parallel"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a590a49ee5d5389a2b966008b3367275772da7f336719fdb0f046ad257f6849"
+dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "rayon",
+]
+
+[[package]]
+name = "commonware-resolver"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e386bcb3a39c2ef1315df245cee346a8d9143961defebeabde518e189f6f54"
+dependencies = [
+ "bytes",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-p2p",
+ "commonware-runtime",
+ "commonware-stream",
+ "commonware-utils",
+ "futures",
+ "prometheus-client",
+ "rand 0.8.5",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "commonware-runtime"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06938675df074ca7749a6d531c4706bcc339e842105e73b03a76d45bd860b349"
+dependencies = [
+ "axum 0.8.8",
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-utils",
+ "criterion 0.7.0",
+ "crossbeam-queue",
+ "futures",
+ "getrandom 0.2.16",
+ "governor",
+ "libc",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "prometheus-client",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rayon",
+ "sha2 0.10.9",
+ "sysinfo",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.3.22",
+]
+
+[[package]]
+name = "commonware-storage"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3be226adc2994ba3b8181f9388855c7f62c5b041ebd8c6a2956651bd8cf95fe"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-parallel",
+ "commonware-runtime",
+ "commonware-utils",
+ "futures",
+ "futures-util",
+ "prometheus-client",
+ "rayon",
+ "thiserror 2.0.17",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "commonware-stream"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24852a37e87406ba53fc95a53574016362cc9f527faf68d298fb1a3f50159950"
+dependencies = [
+ "chacha20poly1305",
+ "commonware-codec",
+ "commonware-cryptography",
+ "commonware-macros",
+ "commonware-runtime",
+ "commonware-utils",
+ "futures",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "thiserror 2.0.17",
+ "x25519-dalek 2.0.1",
+ "zeroize",
+]
+
+[[package]]
+name = "commonware-utils"
+version = "2026.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192eb390e3e0277770982e5e63de72f3c116c810873f3250318cae9ff0206560"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "commonware-codec",
+ "commonware-macros",
+ "futures",
+ "getrandom 0.2.16",
+ "hashbrown 0.16.1",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror 2.0.17",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +2185,26 @@ name = "const-oid"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1205,6 +2298,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +2332,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.5.0",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -1231,6 +2349,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.6.0",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +2379,16 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -1275,6 +2426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,10 +2454,10 @@ dependencies = [
  "anyhow",
  "ark-bls12-381",
  "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "criterion",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "criterion 0.5.1",
  "decaf377",
  "hkdf 0.12.4",
  "poseidon377",
@@ -1382,11 +2542,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bda4de3e070830cf3a27a394de135b6709aefcc54d1e16f2f029271254a6ed9"
 dependencies = [
  "aead 0.6.0-rc.2",
- "chacha20",
+ "chacha20 0.10.0-rc.2",
  "crypto_secretbox",
  "curve25519-dalek 5.0.0-pre.1",
  "salsa20",
- "serdect",
+ "serdect 0.4.1",
  "subtle",
  "zeroize",
 ]
@@ -1398,10 +2558,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54532aae6546084a52cef855593daf9555945719eeeda9974150e0def854873e"
 dependencies = [
  "aead 0.6.0-rc.2",
- "chacha20",
+ "chacha20 0.10.0-rc.2",
  "cipher 0.5.0-rc.1",
  "hybrid-array",
- "poly1305",
+ "poly1305 0.9.0-rc.2",
  "salsa20",
  "subtle",
  "zeroize",
@@ -1423,6 +2583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +2606,21 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
 version = "5.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
@@ -1445,9 +2629,9 @@ dependencies = [
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.11.0-rc.3",
- "fiat-crypto",
+ "fiat-crypto 0.3.0",
  "rand_core 0.9.3",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "subtle",
  "zeroize",
@@ -1478,6 +2662,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,9 +2726,9 @@ dependencies = [
  "ark-bls12-377",
  "ark-ec",
  "ark-ed-on-bls12-377",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "cfg-if",
  "hashbrown 0.14.5",
  "hex",
@@ -1544,6 +2778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1596,7 +2831,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn 2.0.111",
  "unicode-xid",
 ]
@@ -1628,7 +2863,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "x25519-dalek",
+ "x25519-dalek 1.1.1",
 ]
 
 [[package]]
@@ -1725,6 +2960,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +2999,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
+ "serdect 0.2.0",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -1806,6 +3054,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
  "sha2 0.9.9",
+ "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -1840,10 +3089,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1883,6 +3147,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -1921,6 +3186,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +3238,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +3282,12 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
@@ -1984,6 +3297,18 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -2036,6 +3361,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2156,6 +3487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,6 +3511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,8 +3527,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
- "windows-result",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -2248,6 +3591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,6 +3606,29 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -2373,6 +3745,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2383,7 +3757,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "spin 0.9.8",
  "stable_deref_trait",
@@ -2406,6 +3780,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hickory-proto"
@@ -2765,7 +4148,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2775,6 +4158,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ics23"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
+dependencies = [
+ "anyhow",
+ "blake2",
+ "blake3",
+ "bytes",
+ "hex",
+ "informalsystems-pbjson",
+ "prost 0.13.5",
+ "ripemd",
+ "serde",
+ "sha2 0.10.9",
+ "sha3",
 ]
 
 [[package]]
@@ -2859,6 +4261,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,6 +4309,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,6 +4342,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2924,6 +4353,18 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "informalsystems-pbjson"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa4a0980c8379295100d70854354e78df2ee1c6ca0f96ffe89afeb3140e3a3d"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
 ]
 
 [[package]]
@@ -3270,6 +4711,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3282,6 +4732,28 @@ name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+
+[[package]]
+name = "jmt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2a10370b45cd850e64993ccd81d25ea2d4b5b0d0312546e7489fed82064f2e"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "digest 0.10.7",
+ "hashbrown 0.13.2",
+ "hex",
+ "ics23",
+ "itertools 0.10.5",
+ "mirai-annotations",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tracing",
+]
 
 [[package]]
 name = "jni"
@@ -3304,6 +4776,16 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3377,8 +4859,28 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
+ "serdect 0.2.0",
  "sha2 0.10.9",
  "signature 2.2.0",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -3560,6 +5062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,6 +5115,12 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "moka"
@@ -3791,8 +5310,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "web-sys",
- "windows",
- "windows-result",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
  "wmi",
 ]
 
@@ -3813,6 +5332,21 @@ dependencies = [
  "serial_test",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3872,6 +5406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3892,6 +5437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3899,6 +5455,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3921,6 +5487,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3996,6 +5595,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.1",
+ "reqwest 0.12.28",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.1",
+ "tonic 0.14.2",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,10 +5678,11 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 name = "orbis-node"
 version = "0.0.1"
 dependencies = [
+ "acp-light-client",
  "anyhow",
  "ark-bls12-381",
  "ark-ec",
- "ark-std",
+ "ark-std 0.4.0",
  "async-trait",
  "authn",
  "authz",
@@ -4025,6 +5699,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "iroh",
+ "k256",
  "lazy_static",
  "local-storage",
  "network",
@@ -4093,6 +5768,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4118,7 +5821,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4210,6 +5913,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,7 +5939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -4369,6 +6082,17 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
 version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
@@ -4451,12 +6175,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0544874afdaf74b69efc90795c66ea7a494faeb2981a0585d46c757ee2fa94"
 dependencies = [
  "ark-ec",
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-groth16",
  "ark-r1cs-std",
  "ark-relations",
- "ark-serialize",
- "ark-std",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
  "decaf377",
  "poseidon-parameters",
  "poseidon-permutation",
@@ -4531,12 +6255,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4592,6 +6349,48 @@ dependencies = [
  "procfs",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -4718,6 +6517,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4815,6 +6635,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4825,6 +6646,7 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -4882,6 +6704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4891,6 +6724,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4912,6 +6772,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "redb"
@@ -4940,6 +6806,38 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
+dependencies = [
+ "cpufeatures",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5021,6 +6919,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",
@@ -5096,7 +6995,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5107,6 +7006,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -5152,10 +7061,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.2",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -5163,7 +7121,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -5332,7 +7290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5343,7 +7301,7 @@ checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5354,7 +7312,7 @@ checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5362,6 +7320,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5407,6 +7377,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5425,7 +7419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5458,6 +7452,7 @@ dependencies = [
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -5468,7 +7463,19 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.8.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -5476,6 +7483,15 @@ name = "secp256k1-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4473013577ec77b4ee3668179ef1186df3146e2cf2d927bd200974c6fe60fd99"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
@@ -5524,9 +7540,27 @@ checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -5588,6 +7622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,6 +7653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5616,6 +7670,47 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.12.1",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -5718,6 +7813,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5805,6 +7920,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -5859,6 +7977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5893,6 +8020,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -5978,6 +8111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,6 +8146,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6138,7 +8297,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint 0.39.1",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -6152,7 +8311,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tendermint 0.40.4",
- "toml",
+ "toml 0.8.23",
  "url",
 ]
 
@@ -6201,7 +8360,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -6235,7 +8394,7 @@ dependencies = [
  "pin-project",
  "rand 0.8.5",
  "reqwest 0.11.27",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -6300,6 +8459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -6451,6 +8619,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6493,9 +8673,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.12.1",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -6524,7 +8719,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.1",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -6544,9 +8739,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -6556,6 +8751,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -6790,6 +8991,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber 0.3.22",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6818,12 +9035,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -6863,10 +9083,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1 0.10.6",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -6911,6 +9172,12 @@ dependencies = [
  "crypto-common 0.2.0-rc.4",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6976,6 +9243,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -7183,14 +9459,36 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7199,7 +9497,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -7210,9 +9521,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -7221,9 +9543,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7250,9 +9572,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -7260,8 +9598,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7270,9 +9608,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7281,7 +9628,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7290,7 +9646,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7344,7 +9700,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7399,7 +9755,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7412,11 +9768,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7635,8 +10000,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.17",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7656,7 +10021,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.1",
  "send_wrapper",
  "thiserror 2.0.17",
  "wasm-bindgen",
@@ -7681,6 +10046,18 @@ checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
 dependencies = [
  "curve25519-dalek 3.2.0",
  "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+ "serde",
  "zeroize",
 ]
 
@@ -7820,4 +10197,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,12 +46,19 @@ tendermint-rpc = { version = "0.40", features = ["http-client", "websocket-clien
 reqwest = { version = "0.12", features = ["json"] }
 bip32 = { version = "0.5", features = ["mnemonic", "bip39"] }
 k256 = { version = "0.13", features = ["ecdsa"] }
+alloy-primitives = "1.0"
+alloy-consensus = { version = "1.0", features = ["k256"] }
+alloy-eips = "1.0"
+alloy-signer = "1"
+alloy-signer-local = { version = "1", default-features = false }
+alloy-sol-types = "1"
 prost = "0.13"
 tonic = "0.12"
 rand = "0.8"
 base64 = "0.22"
 did-key = "0.2.1"
 project-root = "0.2.2"
+acp-light-client = { git = "https://github.com/sourcenetwork/backbone.git", branch = "main" }
 
 # Metrics
 prometheus = { version = "0.13", features = ["process"] }

--- a/bin/cli-tool/src/commands.rs
+++ b/bin/cli-tool/src/commands.rs
@@ -17,7 +17,7 @@ use crypto::{
     GroupAffine as G1Affine, PreImpl as ThresholdDealerNode, ScalarField as Fr, SignImpl,
 };
 use did_key::{generate, Ed25519KeyPair as DidEd25519KeyPair, Fingerprint};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use proto::dkg_service::dkg_service_client::DkgServiceClient;
@@ -25,6 +25,7 @@ use proto::info_service::info_service_client::InfoServiceClient;
 use proto::pre_service::pre_service_client::PreServiceClient;
 use proto::sign_service::sign_service_client::SignServiceClient;
 use proto::store_secret_service::store_secret_service_client::StoreSecretServiceClient;
+use proto::utility_service::utility_service_client::UtilityServiceClient;
 use tonic::Request;
 
 /// Response structure from PRE server
@@ -37,7 +38,7 @@ struct PreResponse {
 }
 
 /// Result of a DKG operation
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct DkgResult {
     pub session_id: String,
     pub status: String,
@@ -102,7 +103,7 @@ pub async fn do_dkg(endpoint: String, threshold: u32, peer_ids: Vec<String>) -> 
 }
 
 /// Result of a StoreSecret operation
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct StoreSecretResult {
     pub status: String,
     pub message: String,
@@ -889,7 +890,7 @@ pub async fn get_latest_ring(namespace: Option<String>) -> Result<(String, Strin
 }
 
 /// Result of querying node info
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct NodeInfoResult {
     pub public_address: String,
     pub peer_id: String,
@@ -1023,7 +1024,7 @@ pub async fn post_key_derivation(
 }
 
 /// Result of a Sign operation
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct SignResult {
     pub status: String,
     pub message: String,
@@ -1160,4 +1161,161 @@ pub async fn fund(address: String, config: ChainConfig) -> Result<()> {
         max_retries,
         last_error.map(|e| e.to_string()).unwrap_or_default()
     ))
+}
+
+/// Result of a DerivePublicKey operation
+#[derive(Debug, Serialize)]
+pub struct DerivePublicKeyResult {
+    pub derived_public_key: String,
+    pub algorithm: String,
+}
+
+pub async fn derive_public_key(
+    endpoint: String,
+    ring_id: String,
+    derivation: Vec<u8>,
+) -> Result<DerivePublicKeyResult> {
+    eprintln!("Deriving public key:");
+    eprintln!("  Endpoint: {}", endpoint);
+    eprintln!("  Ring ID: {}", ring_id);
+    eprintln!("  Derivation: {}", hex::encode(&derivation));
+    eprintln!();
+
+    let mut client = UtilityServiceClient::connect(endpoint.clone())
+        .await
+        .map_err(|e| anyhow!("Failed to connect to {}: {}", endpoint, e))?;
+
+    let request = Request::new(proto::utility_service::DerivePublicKeyRequest {
+        ring_id,
+        derivation,
+    });
+
+    let response = client
+        .derive_public_key(request)
+        .await
+        .map_err(|e| anyhow!("DerivePublicKey request failed: {}", e))?;
+
+    let response = response.into_inner();
+    let derived_pk_hex = hex::encode(&response.public_key);
+    let algorithm = proto::utility_service::SignAlgorithm::try_from(response.algorithm)
+        .map(|a| a.as_str_name().to_string())
+        .unwrap_or_else(|_| format!("UNKNOWN({})", response.algorithm));
+
+    eprintln!("DerivePublicKey Result:");
+    eprintln!("{}", "=".repeat(60));
+    eprintln!("  Derived PK: {}", derived_pk_hex);
+    eprintln!("  Algorithm:  {}", algorithm);
+
+    Ok(DerivePublicKeyResult {
+        derived_public_key: derived_pk_hex,
+        algorithm,
+    })
+}
+
+/// ACP authorization fields for UtilitySign requests.
+/// When all fields are empty, ACP is not enforced.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SignAcpFields {
+    pub policy_id: String,
+    pub resource: String,
+    pub object_id: String,
+    pub permission: String,
+}
+
+/// Result of a UtilitySign operation
+#[derive(Debug, Serialize)]
+pub struct UtilitySignResult {
+    pub signature: String,
+    pub algorithm: String,
+    pub public_key: String,
+}
+
+/// Compute the Ed25519 did:key that signing functions will use for a given signer private key.
+/// Useful for registering the signer DID in ACP before making Sign calls.
+pub fn signer_did_for_pk(signer_did_pk: &str) -> String {
+    let seed_bytes = hex::decode(signer_did_pk).expect("signer_did_pk must be valid hex");
+    let key_pair = generate::<DidEd25519KeyPair>(Some(&seed_bytes));
+    format!("did:key:{}", key_pair.fingerprint())
+}
+
+/// Call `UtilityService.Sign` for threshold signing via the utility pathway.
+///
+/// Uses ring_id directly (no bulletin KeyDerivation lookup required).
+pub async fn do_utility_sign(
+    endpoint: String,
+    ring_id: String,
+    message: Vec<u8>,
+    derivation: Option<Vec<u8>>,
+    signer_did_pk: Option<String>,
+    acp: Option<SignAcpFields>,
+) -> Result<UtilitySignResult> {
+    eprintln!("Threshold signing (UtilityService):");
+    eprintln!("  Endpoint: {}", endpoint);
+    eprintln!("  Ring ID: {}", ring_id);
+    eprintln!("  Message len: {}", message.len());
+    eprintln!();
+
+    let mut client = UtilityServiceClient::connect(endpoint.clone())
+        .await
+        .map_err(|e| anyhow!("Failed to connect to {}: {}", endpoint, e))?;
+
+    let acp = acp.unwrap_or_default();
+    let derivation_bytes = derivation.clone().unwrap_or_default();
+    let request = proto::utility_service::SignRequest {
+        ring_id: ring_id.clone(),
+        message: message.clone(),
+        derivation: derivation_bytes,
+        algorithm: 0, // UNSPECIFIED — use ring's native algorithm
+        options: std::collections::HashMap::new(),
+        policy_id: acp.policy_id.clone(),
+        resource: acp.resource.clone(),
+        object_id: acp.object_id.clone(),
+        permission: acp.permission.clone(),
+        decision_id: String::new(),
+    };
+
+    // Create JWT for authentication
+    let signer_did_pk = signer_did_pk.unwrap_or("test_jwt".to_string());
+    let seed_bytes = hex::decode(&signer_did_pk)
+        .unwrap_or_else(|_| signer_did_pk.as_bytes().to_vec());
+    let key_pair = generate::<DidEd25519KeyPair>(Some(&seed_bytes));
+    let jwt_signer = JwtSigner::from_key_pair(key_pair);
+    let token = jwt_signer
+        .create_utility_sign_jwt(
+            &ring_id,
+            message,
+            derivation,
+            &acp.policy_id,
+            &acp.resource,
+            &acp.object_id,
+            &acp.permission,
+        )
+        .map_err(|e| anyhow!("Failed to create JWT: {}", e))?;
+
+    let tonic_request = create_authenticated_request(request, &token)
+        .map_err(|e| anyhow!("Failed to create authenticated request: {}", e))?;
+
+    let response = client
+        .sign(tonic_request)
+        .await
+        .map_err(|e| anyhow!("Sign request failed: {}", e))?;
+
+    let response = response.into_inner();
+    let signature_hex = hex::encode(&response.signature);
+    let algorithm = proto::utility_service::SignAlgorithm::try_from(response.algorithm)
+        .map(|a| a.as_str_name().to_string())
+        .unwrap_or_else(|_| format!("UNKNOWN({})", response.algorithm));
+    let public_key_hex = hex::encode(&response.public_key);
+
+    eprintln!("Sign Result:");
+    eprintln!("{}", "=".repeat(60));
+    eprintln!("  Signature:  {}", signature_hex);
+    eprintln!("  Algorithm:  {}", algorithm);
+    eprintln!("  Public Key: {}", public_key_hex);
+
+    Ok(UtilitySignResult {
+        signature: signature_hex,
+        algorithm,
+        public_key: public_key_hex,
+    })
 }

--- a/bin/cli-tool/src/lib.rs
+++ b/bin/cli-tool/src/lib.rs
@@ -6,10 +6,11 @@ mod commands;
 
 // Re-export the main CLI functions for integration testing
 pub use commands::{
-    add_bulletin_collaborator, add_policy_to_chain, create_bulletin_post, do_dkg,
-    do_encrypt_secret, do_generate_reader_key, do_pre, do_sign, do_store_secret, fund,
-    get_account_sequence, get_latest_ring, list_bulletin_posts, post_key_derivation,
-    prepare_secret, query_node_info, read_bulletin_post, register_bulletin_namespace,
-    register_object_to_chain, set_relationship_on_chain, store_prepared_secret, DkgResult,
-    NodeInfoResult, PreparedSecret, SignResult, StoreSecretResult,
+    add_bulletin_collaborator, add_policy_to_chain, create_bulletin_post, derive_public_key,
+    do_dkg, do_encrypt_secret, do_generate_reader_key, do_pre, do_sign, do_store_secret,
+    do_utility_sign, fund, get_account_sequence, get_latest_ring, list_bulletin_posts,
+    post_key_derivation, prepare_secret, query_node_info, read_bulletin_post,
+    register_bulletin_namespace, register_object_to_chain, set_relationship_on_chain,
+    signer_did_for_pk, store_prepared_secret, DerivePublicKeyResult, DkgResult, NodeInfoResult,
+    PreparedSecret, SignAcpFields, SignResult, StoreSecretResult, UtilitySignResult,
 };

--- a/bin/cli-tool/src/main.rs
+++ b/bin/cli-tool/src/main.rs
@@ -1,21 +1,32 @@
 mod commands;
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 pub use commands::{
-    add_bulletin_collaborator, add_policy_to_chain, create_bulletin_post, do_dkg,
-    do_encrypt_secret, do_generate_reader_key, do_pre, do_sign, do_store_secret, fund,
-    get_account_sequence, get_latest_ring, list_bulletin_posts, post_key_derivation,
-    prepare_secret, query_node_info, read_bulletin_post, register_bulletin_namespace,
-    register_object_to_chain, set_relationship_on_chain, store_prepared_secret, PreparedSecret,
-    SignResult,
+    add_bulletin_collaborator, add_policy_to_chain, create_bulletin_post, derive_public_key,
+    do_dkg, do_encrypt_secret, do_generate_reader_key, do_pre, do_sign, do_store_secret,
+    do_utility_sign, fund, get_account_sequence, get_latest_ring, list_bulletin_posts,
+    post_key_derivation, prepare_secret, query_node_info, read_bulletin_post,
+    register_bulletin_namespace, register_object_to_chain, set_relationship_on_chain,
+    signer_did_for_pk, store_prepared_secret, DerivePublicKeyResult, PreparedSecret,
+    SignAcpFields, SignResult, UtilitySignResult,
 };
 use common::blockchain::ChainConfig;
 use hex;
 
+#[derive(Debug, Clone, ValueEnum)]
+enum OutputFormat {
+    Text,
+    Json,
+}
+
 #[derive(Parser, Debug, Clone)]
 #[clap(version, about = "CLI tool for interacting with an orbis network")]
 pub struct Cli {
+    /// Output format (text or json)
+    #[clap(long, value_enum, default_value = "text", global = true)]
+    output: OutputFormat,
+
     #[clap(subcommand)]
     command: SubCommands,
 }
@@ -350,7 +361,7 @@ pub enum SubCommands {
         #[clap(long)]
         proof: String,
     },
-    /// Start a threshold Sign session (Policy pathway)
+    /// Start a threshold Sign session (Policy pathway via SignService)
     Sign {
         /// gRPC endpoint of the node to use
         #[clap(short, long, default_value = "http://localhost:50051")]
@@ -373,6 +384,54 @@ pub enum SubCommands {
         /// End of the validity window (Unix timestamp, inclusive). Requires --valid-window-start.
         #[clap(long)]
         valid_window_end: Option<u64>,
+    },
+    /// Start a threshold Sign session (UtilityService pathway, direct ring_id)
+    UtilitySign {
+        /// gRPC endpoint of the node to use
+        #[clap(short, long, default_value = "http://localhost:50051")]
+        endpoint: String,
+        /// Ring ID to sign with
+        #[clap(long)]
+        ring_id: String,
+        /// Message to sign (hex encoded)
+        #[clap(long)]
+        message: String,
+        /// Optional derivation path (hex encoded)
+        #[clap(long)]
+        derivation: Option<String>,
+        /// Signer DID private key (hex) for JWT authentication
+        #[clap(long)]
+        signer_did_pk: Option<String>,
+        /// ACP policy ID (optional)
+        #[clap(long)]
+        policy_id: Option<String>,
+        /// ACP resource type (optional)
+        #[clap(long)]
+        resource: Option<String>,
+        /// ACP object ID (optional)
+        #[clap(long)]
+        object_id: Option<String>,
+        /// ACP permission (optional)
+        #[clap(long)]
+        permission: Option<String>,
+    },
+    /// Derive a public key from a ring's master key and derivation path
+    DerivePublicKey {
+        /// gRPC endpoint of the node to use
+        #[clap(short, long, default_value = "http://localhost:50051")]
+        endpoint: String,
+        /// Ring ID
+        #[clap(long)]
+        ring_id: String,
+        /// Derivation path (hex encoded)
+        #[clap(long)]
+        derivation: String,
+    },
+    /// Print the DID URI for a given signer private key (hex)
+    SignerDid {
+        /// Signer private key (hex encoded, 32 bytes)
+        #[clap(long)]
+        signer_did_pk: String,
     },
 }
 
@@ -662,7 +721,7 @@ async fn main() -> Result<()> {
             }
             let message_bytes = hex::decode(&message)
                 .map_err(|e| anyhow::anyhow!("Failed to decode message hex: {}", e))?;
-            do_sign(
+            let result = do_sign(
                 endpoint,
                 message_bytes,
                 namespace,
@@ -672,6 +731,67 @@ async fn main() -> Result<()> {
                 valid_window_end,
             )
             .await?;
+            if matches!(cli.output, OutputFormat::Json) {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+        SubCommands::UtilitySign {
+            endpoint,
+            ring_id,
+            message,
+            derivation,
+            signer_did_pk,
+            policy_id,
+            resource,
+            object_id,
+            permission,
+        } => {
+            let message_bytes = hex::decode(&message)
+                .map_err(|e| anyhow::anyhow!("Failed to decode message hex: {}", e))?;
+            let derivation_bytes =
+                derivation.map(|d| hex::decode(&d).expect("Failed to decode derivation hex"));
+            let acp = if policy_id.is_some() || resource.is_some() || object_id.is_some() || permission.is_some() {
+                Some(SignAcpFields {
+                    policy_id: policy_id.unwrap_or_default(),
+                    resource: resource.unwrap_or_default(),
+                    object_id: object_id.unwrap_or_default(),
+                    permission: permission.unwrap_or_default(),
+                })
+            } else {
+                None
+            };
+            let result = do_utility_sign(
+                endpoint,
+                ring_id,
+                message_bytes,
+                derivation_bytes,
+                signer_did_pk,
+                acp,
+            )
+            .await?;
+            if matches!(cli.output, OutputFormat::Json) {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+        SubCommands::DerivePublicKey {
+            endpoint,
+            ring_id,
+            derivation,
+        } => {
+            let derivation_bytes = hex::decode(&derivation)
+                .map_err(|e| anyhow::anyhow!("Failed to decode derivation hex: {}", e))?;
+            let result = derive_public_key(endpoint, ring_id, derivation_bytes).await?;
+            if matches!(cli.output, OutputFormat::Json) {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            }
+        }
+        SubCommands::SignerDid { signer_did_pk } => {
+            let did = signer_did_for_pk(&signer_did_pk);
+            if matches!(cli.output, OutputFormat::Json) {
+                println!("{}", serde_json::to_string_pretty(&serde_json::json!({"did": did}))?);
+            } else {
+                println!("{}", did);
+            }
         }
     }
 

--- a/bin/orbis-node/Cargo.toml
+++ b/bin/orbis-node/Cargo.toml
@@ -13,7 +13,7 @@ local-storage = { path = "../../crates/local-storage", default-features = false 
 proto = { path = "../../crates/proto" }
 authn = { path = "../../crates/authn" }
 authz = { path = "../../crates/authz" }
-bulletin = { path = "../../crates/bulletin" }
+bulletin = { path = "../../crates/bulletin", default-features = false }
 tonic = "0.14.2"
 iroh = { workspace = true }
 tokio = { workspace = true }
@@ -35,6 +35,8 @@ tracing-loki = "0.2"
 url = "2.5"
 sha2 = { workspace = true }
 common = { path = "../../crates/common" }
+acp-light-client = { workspace = true }
+k256 = { workspace = true, optional = true }
 project-root = { workspace = true }
 cli-tool = { path = "../cli-tool", optional = true, default-features = false }
 prometheus = { workspace = true }
@@ -62,6 +64,7 @@ redb = ["local-storage/redb"]
 memory = ["local-storage/memory"]
 authz-sourcehub = ["authz/sourcehub"]
 bulletin-sourcehub = ["bulletin/sourcehub"]
+bulletin-hubrs = ["bulletin/hubrs", "dep:k256"]
 iroh = ["network/iroh"]
 integration-test = ["cli-tool"]
 fault-injection = ["network/fault-injection"]

--- a/bin/orbis-node/src/app_state.rs
+++ b/bin/orbis-node/src/app_state.rs
@@ -1,6 +1,7 @@
 use crate::dkg::session_state::SessionStateManager;
 use crate::pre::response_state::PreResponseManager;
 use crate::sign::response_state::SignResponseManager;
+use acp_light_client::AcpLightClient;
 use authz::r#trait::Authz;
 use bulletin::r#trait::Bulletin;
 use crypto::r#trait::Dkg;
@@ -31,6 +32,8 @@ where
     pub authz: Arc<dyn Authz + Send + Sync>,
     /// Bulletin implementation
     pub bulletin: Arc<dyn Bulletin + Send + Sync>,
+    /// Optional ACP light client for AccessDecision verification
+    pub acp_light_client: Option<Arc<AcpLightClient>>,
 }
 
 /// Server configuration
@@ -50,6 +53,7 @@ where
         local_storage: LocalStorageImpl,
         authz: Arc<dyn Authz + Send + Sync>,
         bulletin: Arc<dyn Bulletin + Send + Sync>,
+        acp_light_client: Option<Arc<AcpLightClient>>,
     ) -> Self {
         Self {
             config: ServerConfig { bind_address },
@@ -60,6 +64,7 @@ where
             sign_response_state: Arc::new(SignResponseManager::new()),
             authz,
             bulletin,
+            acp_light_client,
         }
     }
 }

--- a/bin/orbis-node/src/helpers/launch.rs
+++ b/bin/orbis-node/src/helpers/launch.rs
@@ -37,12 +37,25 @@ pub struct Args {
     /// denomination of chain gas tokens
     #[arg(long)]
     pub denom: Option<String>,
+    /// Data directory for all node state (database, keys). Isolates this node's
+    /// storage from other nodes on the same machine.
+    #[arg(short = 'd', long)]
+    pub data_dir: Option<String>,
     /// Address for Prometheus metrics HTTP server (e.g., "0.0.0.0:9090")
     #[arg(short = 'm', long)]
     pub metrics_addr: Option<String>,
     /// Loki server URL for log aggregation (e.g., "http://localhost:3100")
     #[arg(long)]
     pub loki_url: Option<String>,
+    /// Hub.rs HTTP RPC endpoint for ACP light client (e.g., "http://127.0.0.1:9944")
+    #[arg(long)]
+    pub hub_rpc: Option<String>,
+    /// Hub.rs WebSocket endpoint for ACP light client (e.g., "ws://127.0.0.1:9944")
+    #[arg(long)]
+    pub hub_ws: Option<String>,
+    /// Hub.rs EVM chain ID (default: 9944)
+    #[arg(long, default_value = "9944")]
+    pub hub_chain_id: u64,
 }
 
 // ============================================================================
@@ -293,43 +306,105 @@ impl From<LogLevel> for tracing::Level {
     }
 }
 
-pub fn db_path(name: &str) -> String {
-    // Try to get project root (works in dev environment), fall back to /data for Docker
-    let base_path = match project_root::get_project_root() {
+/// Resolve the base directory for node state files.
+///
+/// Priority: explicit `--data-dir` flag > project root > `/data` (Docker) > cwd.
+pub fn resolve_base_dir(data_dir: Option<&str>) -> PathBuf {
+    if let Some(dir) = data_dir {
+        let p = PathBuf::from(dir);
+        std::fs::create_dir_all(&p).ok();
+        return p;
+    }
+    match project_root::get_project_root() {
         Ok(root) => root,
         Err(_) => {
-            // In Docker or other environments without Cargo.toml, use /data or current dir
-            let data_dir = std::path::PathBuf::from("/data");
-            if data_dir.exists() {
-                data_dir
+            let docker_dir = PathBuf::from("/data");
+            if docker_dir.exists() {
+                docker_dir
             } else {
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+                std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
             }
         }
-    };
-    let db_dir = base_path.join("dbs");
-    // Create the dbs directory if it doesn't exist
+    }
+}
+
+pub fn db_path(name: &str, data_dir: Option<&str>) -> String {
+    // ORBIS_DB_PATH env var overrides all other logic (full file path)
+    if let Ok(path) = env::var("ORBIS_DB_PATH") {
+        if !path.is_empty() {
+            return path;
+        }
+    }
+
+    let base = resolve_base_dir(data_dir);
+    // With explicit --data-dir, put the db directly in it.
+    // With auto-resolved root, use a "dbs" subdirectory to keep things tidy.
+    let db_dir = if data_dir.is_some() { base } else { base.join("dbs") };
     std::fs::create_dir_all(&db_dir).ok();
     format!("{}/{}.redb", db_dir.display(), name)
+}
+
+/// Get or create the node signing key and return the raw hex string.
+/// This extracts the key management logic shared by both Cosmos (SourceHub)
+/// and EVM (hub.rs) backends. The caller wraps it in the appropriate signer.
+pub fn get_or_create_signing_key_hex(
+    local_storage: LocalStorageImpl,
+    data_dir: Option<&str>,
+) -> Result<String, String> {
+    let base_path = resolve_base_dir(data_dir);
+    let public_key_path = base_path.join("public_key.txt");
+
+    let hex_key = match local_storage.get_encrypted(LocalStorageKeys::NodeSigningKey) {
+        Ok(Some(key_bytes)) => {
+            let hex_key = String::from_utf8(key_bytes)
+                .map_err(|e| format!("Failed to parse stored key as UTF-8: {}", e))?;
+            tracing::info!("Existing signing key loaded from storage");
+            hex_key
+        }
+        Ok(None) => {
+            tracing::info!("No signing key found, generating new one");
+            let mut key_bytes = [0u8; 32];
+            getrandom::getrandom(&mut key_bytes)
+                .map_err(|e| format!("Failed to generate random bytes: {}", e))?;
+            let hex_key = hex::encode(key_bytes);
+            local_storage
+                .set_encrypted(
+                    LocalStorageKeys::NodeSigningKey,
+                    hex_key.as_bytes().to_vec(),
+                )
+                .map_err(|e| format!("Failed to store signing key: {}", e))?;
+            hex_key
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Error reading signing key from storage, generating new one");
+            let mut key_bytes = [0u8; 32];
+            getrandom::getrandom(&mut key_bytes)
+                .map_err(|e| format!("Failed to generate random bytes: {}", e))?;
+            let hex_key = hex::encode(key_bytes);
+            local_storage
+                .set_encrypted(
+                    LocalStorageKeys::NodeSigningKey,
+                    hex_key.as_bytes().to_vec(),
+                )
+                .map_err(|e| format!("Failed to store signing key: {}", e))?;
+            hex_key
+        }
+    };
+
+    // Write public key info to file for operator visibility
+    // For EVM this will be overwritten with the EVM address by the caller if needed
+    fs::write(&public_key_path, &hex_key[..16])
+        .map_err(|e| format!("Failed to write public key to file: {}", e))?;
+
+    Ok(hex_key)
 }
 
 pub fn create_and_store_node_key(
     local_storage: LocalStorageImpl,
     config: ChainConfig,
+    data_dir: Option<&str>,
 ) -> Result<TxSigner, String> {
-    // Write public key to file - try project root first, fall back to /data or current dir
-    let base_path = match project_root::get_project_root() {
-        Ok(root) => root,
-        Err(_) => {
-            // In Docker or other environments without Cargo.toml, use /data or current dir
-            let data_dir = std::path::PathBuf::from("/data");
-            if data_dir.exists() {
-                data_dir
-            } else {
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
-            }
-        }
-    };
+    let base_path = resolve_base_dir(data_dir);
     let public_key_path = base_path.join("public_key.txt");
 
     // Check if a signing key exists in DB

--- a/bin/orbis-node/src/helpers/test_helpers.rs
+++ b/bin/orbis-node/src/helpers/test_helpers.rs
@@ -108,7 +108,7 @@ pub async fn create_test_app_state_with_bulletin(
     }
 
     // Create AppState with the network (node_id is no longer needed - it's session-specific)
-    AppState::<DkgImpl>::new(bind_address, network, local_storage, authz, bulletin)
+    AppState::<DkgImpl>::new(bind_address, network, local_storage, authz, bulletin, None)
 }
 
 /// Create a test AppState with default values

--- a/bin/orbis-node/src/info/tests.rs
+++ b/bin/orbis-node/src/info/tests.rs
@@ -17,7 +17,7 @@ async fn test_get_node_info() {
 
     // Create and store a node signing key so get_node_signer can retrieve it
     let config = ChainConfigBuilder::default().build();
-    create_and_store_node_key(app_state.local_storage.clone(), config.clone())
+    create_and_store_node_key(app_state.local_storage.clone(), config.clone(), None)
         .expect("Failed to create and store node key");
 
     // Create the info service

--- a/bin/orbis-node/src/main.rs
+++ b/bin/orbis-node/src/main.rs
@@ -9,6 +9,7 @@ pub mod metrics;
 pub mod pre;
 pub mod sign;
 pub mod store_secret;
+pub mod utility;
 
 #[cfg(test)]
 mod tests;
@@ -16,13 +17,18 @@ mod tests;
 use crate::dkg::service::DkgServiceImpl;
 use crate::helpers::create_routers::create_router_with_all_handlers;
 use crate::helpers::launch::{
-    create_and_store_node_key, db_path, derive_secret_key_bytes, get_network_key_secret,
+    db_path, derive_secret_key_bytes, get_network_key_secret,
     get_password, Args,
 };
+#[cfg(feature = "bulletin-sourcehub")]
+use crate::helpers::launch::create_and_store_node_key;
+#[cfg(feature = "bulletin-hubrs")]
+use crate::helpers::launch::{get_or_create_signing_key_hex, resolve_base_dir};
 use crate::info::InfoServiceImpl;
 use crate::pre::service::PreServiceImpl;
 use crate::sign::service::SignServiceImpl;
 use crate::store_secret::StoreSecretServiceImpl;
+use crate::utility::UtilityServiceImpl;
 use app_state::AppState;
 use authz::r#trait::Authz;
 use authz::AuthzImpl;
@@ -34,6 +40,7 @@ use local_storage::{r#trait::LocalStorage, LocalStorageImpl};
 use network::{Network, NetworkImpl, Router};
 use std::{net::SocketAddr, sync::Arc};
 // Concrete crypto implementations
+#[cfg(feature = "bulletin-sourcehub")]
 use constants::MIN_NODE_BALANCE;
 use crypto::{DkgImpl, PreImpl, SignImpl};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -43,6 +50,7 @@ use proto::info_service::info_service_server::InfoServiceServer;
 use proto::pre_service::pre_service_server::PreServiceServer;
 use proto::sign_service::sign_service_server::SignServiceServer;
 use proto::store_secret_service::store_secret_service_server::StoreSecretServiceServer;
+use proto::utility_service::utility_service_server::UtilityServiceServer;
 
 /// Configuration for running the node, allowing dependency injection for testing
 pub struct NodeConfig {
@@ -51,6 +59,7 @@ pub struct NodeConfig {
     pub local_storage: LocalStorageImpl,
     pub authz: Arc<dyn Authz>,
     pub bulletin: Arc<dyn Bulletin + Send + Sync>,
+    pub acp_light_client: Option<Arc<acp_light_client::AcpLightClient>>,
 }
 
 /// Result of initializing the node (before starting the server)
@@ -99,6 +108,7 @@ pub async fn init_node(config: NodeConfig) -> Result<InitializedNode, Box<dyn st
         config.local_storage,
         config.authz,
         config.bulletin,
+        config.acp_light_client,
     );
     let app_state_arc = Arc::new(app_state);
 
@@ -148,14 +158,17 @@ pub async fn run_server(node: InitializedNode) -> Result<(), Box<dyn std::error:
     let store_secret_service =
         StoreSecretServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
     let sign_service = SignServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
+    let utility_service =
+        UtilityServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
 
-    // Start gRPC server
+    // Start gRPC server with DKG, PRE, Info, StoreSecret, Sign, and Utility services
     let grpc_server = tonic::transport::Server::builder()
         .add_service(DkgServiceServer::new(dkg_service))
         .add_service(PreServiceServer::new(pre_service))
         .add_service(InfoServiceServer::new(info_service))
         .add_service(StoreSecretServiceServer::new(store_secret_service))
         .add_service(SignServiceServer::new(sign_service))
+        .add_service(UtilityServiceServer::new(utility_service))
         .serve(node.grpc_addr);
 
     // Run gRPC server (router runs in background automatically)
@@ -230,8 +243,9 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     // Get password for encrypting ring key shares
     let password = get_password(None).map_err(|e| format!("Failed to get password: {}", e))?;
-    let local_storage = LocalStorageImpl::new(Some(password), db_path("orbis"))
-        .map_err(|e| format!("Failed to create local storage: {}", e))?;
+    let local_storage =
+        LocalStorageImpl::new(Some(password), db_path("orbis", args.data_dir.as_deref()))
+            .map_err(|e| format!("Failed to create local storage: {}", e))?;
     // Get node secret hex for netwokring
     let node_secret_hex = get_network_key_secret(None, local_storage.clone())
         .map_err(|e| format!("Failed to get node secret: {}", e))?;
@@ -262,36 +276,87 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("Failed to initialize authz: {}", e))?,
     );
 
-    let bulletin_chain_config = ChainConfigBuilder::default()
-        .grpc_url(args.bulletin_grpc.clone())
-        .rpc_url(args.chain_rpc.clone())
-        .rest_url(args.chain_rest.clone())
-        .denom(args.denom.clone());
-    let chain_config = bulletin_chain_config.clone().build();
-    let signer = create_and_store_node_key(local_storage.clone(), chain_config)
-        .map_err(|e| format!("Failed to create or store node key: {}", e))?;
-
-    // For integration tests, this funds the account, this is handled differently live
-    // Only fund if both the feature is enabled AND we're in the integration test network
-    #[cfg(feature = "integration-test")]
-    {
-        // Build chain config with the provided RPC/REST URLs
-        let fund_config = ChainConfigBuilder::default()
+    // Initialize bulletin backend (SourceHub or hub.rs, mutually exclusive)
+    #[cfg(feature = "bulletin-sourcehub")]
+    let bulletin: Arc<BulletinImpl> = {
+        let chain_config_builder = ChainConfigBuilder::default()
+            .grpc_url(args.bulletin_grpc.clone())
             .rpc_url(args.chain_rpc.clone())
             .rest_url(args.chain_rest.clone())
-            .grpc_url(args.bulletin_grpc.clone())
-            .build();
-        cli_tool::fund(signer.address(), fund_config)
-            .await
-            .expect("issue with faucet");
-    }
+            .denom(args.denom.clone());
+        let signer = create_and_store_node_key(local_storage.clone(), chain_config_builder.clone().build(), args.data_dir.as_deref())
+            .map_err(|e| format!("Failed to create or store node key: {}", e))?;
 
-    // TODO: consider checking that you have connected to the chain succefully and not break tests (here or in impl)
-    let bulletin: Arc<BulletinImpl> = Arc::new(
-        BulletinImpl::with_signer(bulletin_chain_config, signer, Some(MIN_NODE_BALANCE))
-            .await
-            .map_err(|e| format!("Failed to initialize bulletin: {}", e))?,
-    );
+        // For integration tests, this funds the account, this is handled differently live
+        #[cfg(feature = "integration-test")]
+        {
+            cli_tool::fund(signer.address(), chain_config_builder.clone().build())
+                .await
+                .expect("issue with faucet");
+        }
+
+        Arc::new(
+            BulletinImpl::with_signer(chain_config_builder, signer, Some(MIN_NODE_BALANCE))
+                .await
+                .map_err(|e| format!("Failed to initialize bulletin: {}", e))?,
+        )
+    };
+
+    #[cfg(feature = "bulletin-hubrs")]
+    let bulletin: Arc<BulletinImpl> = {
+        let hub_rpc = args
+            .hub_rpc
+            .clone()
+            .ok_or("--hub-rpc is required when using the hubrs bulletin backend")?;
+        let hex_key = get_or_create_signing_key_hex(local_storage.clone(), args.data_dir.as_deref())
+            .map_err(|e| format!("Failed to create or retrieve signing key: {}", e))?;
+        let config = bulletin::hubrs::HubRsConfig {
+            rpc_url: hub_rpc,
+            chain_id: args.hub_chain_id,
+        };
+
+        // Compute and write EVM address to public_key.txt
+        let evm_signer = bulletin::hubrs::signer::EvmSigner::from_hex(&hex_key, args.hub_chain_id)
+            .map_err(|e| format!("compute EVM address: {}", e))?;
+        let evm_address = format!("{:?}", evm_signer.address());
+        let base_path = resolve_base_dir(args.data_dir.as_deref());
+        std::fs::write(base_path.join("public_key.txt"), &evm_address)
+            .map_err(|e| format!("write EVM address: {}", e))?;
+
+        // Write compressed secp256k1 public key for DID derivation by test harness
+        let signing_key = k256::ecdsa::SigningKey::from_slice(
+            &hex::decode(&hex_key).map_err(|e| format!("hex decode signing key: {}", e))?,
+        )
+        .map_err(|e| format!("parse signing key: {}", e))?;
+        let compressed_pubkey = signing_key.verifying_key().to_encoded_point(true);
+        std::fs::write(
+            base_path.join("signer_pubkey.txt"),
+            hex::encode(compressed_pubkey.as_bytes()),
+        )
+        .map_err(|e| format!("write signer pubkey: {}", e))?;
+
+        tracing::info!(address = %evm_address, "EVM signing address ready");
+
+        Arc::new(
+            BulletinImpl::with_signer(config, &hex_key)
+                .map_err(|e| format!("Failed to initialize hub.rs bulletin: {}", e))?,
+        )
+    };
+
+    // Optionally construct ACP light client if hub.rs URLs are configured
+    let acp_light_client = match (&args.hub_rpc, &args.hub_ws) {
+        (Some(rpc), Some(ws)) => {
+            tracing::info!(hub_rpc = %rpc, hub_ws = %ws, "Initializing ACP light client");
+            let client = acp_light_client::AcpLightClient::new(rpc, ws, 10)
+                .await
+                .map_err(|e| format!("Failed to initialize ACP light client: {}", e))?;
+            Some(Arc::new(client))
+        }
+        _ => {
+            tracing::info!("ACP light client not configured (--hub-rpc and --hub-ws not set)");
+            None
+        }
+    };
 
     let config = NodeConfig {
         args,
@@ -299,6 +364,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         local_storage,
         authz,
         bulletin,
+        acp_light_client,
     };
 
     let node = init_node(config).await?;

--- a/bin/orbis-node/src/sign/coordinator.rs
+++ b/bin/orbis-node/src/sign/coordinator.rs
@@ -149,33 +149,49 @@ where
             ..
         } = req;
         // Auth check first — fail fast before burning a nonce.
-        if let SignContext::Policy {
-            ref token_string,
-            ref namespace,
-            ref derivation_id,
-            ref valid_window,
-            ..
-        } = context
-        {
-            let current_time = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_err(|e| SignError::Generic(format!("Failed to get timestamp: {}", e)))?
-                .as_secs();
-            let token: BearerToken<SignClaims> =
-                resolve_jwt_did(token_string, current_time, MAX_TOKEN_LIFETIME_SECS).map_err(
-                    |e| SignError::Unauthorized(format!("JWT validation failed: {}", e)),
-                )?;
-            validate_sign_claims(&token, namespace, derivation_id, None)?;
-            let key_derivation =
-                fetch_key_derivation(&*self.app_state.bulletin, namespace, derivation_id).await?;
-            check_policy_access(
-                &*self.app_state.authz,
-                &key_derivation,
-                derivation_id,
-                &token.issuer_id,
-                valid_window.clone(),
-            )
-            .await?;
+        match &context {
+            SignContext::Policy {
+                ref token_string,
+                ref namespace,
+                ref derivation_id,
+                ref valid_window,
+                ..
+            } => {
+                let current_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| SignError::Generic(format!("Failed to get timestamp: {}", e)))?
+                    .as_secs();
+                let token: BearerToken<SignClaims> =
+                    resolve_jwt_did(token_string, current_time, MAX_TOKEN_LIFETIME_SECS).map_err(
+                        |e| SignError::Unauthorized(format!("JWT validation failed: {}", e)),
+                    )?;
+                validate_sign_claims(&token, namespace, derivation_id, None)?;
+                let key_derivation =
+                    fetch_key_derivation(&*self.app_state.bulletin, namespace, derivation_id)
+                        .await?;
+                check_policy_access(
+                    &*self.app_state.authz,
+                    &key_derivation,
+                    derivation_id,
+                    &token.issuer_id,
+                    valid_window.clone(),
+                )
+                .await?;
+            }
+            SignContext::Authenticated { ref jwt, .. } | SignContext::AccessDecision { ref jwt, .. } => {
+                // Validate JWT — responder independently verifies the token is valid
+                let current_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| SignError::Generic(format!("Failed to get timestamp: {}", e)))?
+                    .as_secs();
+                let _token: BearerToken<()> =
+                    resolve_jwt_did(jwt, current_time, MAX_TOKEN_LIFETIME_SECS).map_err(|e| {
+                        SignError::Unauthorized(format!("JWT validation failed: {}", e))
+                    })?;
+            }
+            SignContext::Bulletin => {
+                // Bulletin context: no pre-auth needed, message existence is checked in Round 2
+            }
         }
 
         // Auth passed — load share and generate nonce.
@@ -197,6 +213,8 @@ where
         let context_key = match &context {
             SignContext::Bulletin => "bulletin".to_string(),
             SignContext::Policy { derivation_id, .. } => derivation_id.clone(),
+            SignContext::Authenticated { ring_id, .. } => format!("auth-{}", ring_id),
+            SignContext::AccessDecision { ring_id, .. } => format!("decision-{}", ring_id),
         };
 
         if !self
@@ -309,6 +327,156 @@ where
 
                 (ring_payload.ring_pk, pub_poly, derivation, metadata)
             }
+            SignContext::Authenticated {
+                ref jwt,
+                ref ring_id,
+                ref policy_id,
+                ref resource,
+                ref object_id,
+                ref permission,
+            } => {
+                // Validate JWT independently
+                let current_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| SignError::Generic(format!("Failed to get timestamp: {}", e)))?
+                    .as_secs();
+                let token: BearerToken<()> =
+                    resolve_jwt_did(jwt, current_time, MAX_TOKEN_LIFETIME_SECS).map_err(|e| {
+                        SignError::Unauthorized(format!("JWT validation failed: {}", e))
+                    })?;
+
+                // ACP check if policy_id is set
+                if !policy_id.is_empty() {
+                    use authz::sourcehub::AccessCheckRequest;
+                    let permission_bytes = AccessCheckRequest::new(
+                        policy_id.clone(),
+                        resource.clone(),
+                        object_id.clone(),
+                        permission.clone(),
+                        None,
+                        None,
+                        None,
+                    )
+                    .to_bytes()
+                    .map_err(|e| {
+                        SignError::AuthZ(format!("Error formatting access request: {}", e))
+                    })?;
+                    let authorized = self
+                        .app_state
+                        .authz
+                        .check(permission_bytes, &token.issuer_id)
+                        .await
+                        .map_err(|e| {
+                            SignError::AuthZ(format!("ACP authorization failed: {}", e))
+                        })?;
+                    if !authorized {
+                        return Err(SignError::AuthZ(format!(
+                            "ACP denied: {} not authorized for {}/{}/{}",
+                            token.issuer_id, resource, object_id, permission,
+                        )));
+                    }
+                }
+
+                // Look up ring info from bulletin
+                let ring_info = self
+                    .app_state
+                    .bulletin
+                    .read(BULLETIN_RING_NAMESPACE.to_string(), ring_id.clone())
+                    .await
+                    .map_err(|e| {
+                        SignError::VerificationFailed(format!(
+                            "Failed to read ring '{}': {}",
+                            ring_id, e
+                        ))
+                    })?;
+                let ring_payload =
+                    serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                        SignError::Deserialization(format!("Failed to parse ring payload: {}", e))
+                    })?;
+
+                let pub_poly_bytes =
+                    hex::decode(&ring_payload.public_polynomial).map_err(|e| {
+                        SignError::Deserialization(format!(
+                            "Failed to decode public polynomial hex: {}",
+                            e
+                        ))
+                    })?;
+                let pub_poly = <D::PubPoly>::from_bytes(&pub_poly_bytes).map_err(|e| {
+                    SignError::Deserialization(format!(
+                        "Failed to deserialize public polynomial: {}",
+                        e
+                    ))
+                })?;
+
+                (ring_payload.ring_pk, pub_poly, None, None)
+            }
+            SignContext::AccessDecision {
+                ref jwt,
+                ref ring_id,
+                ref decision_id,
+            } => {
+                // Validate JWT independently
+                let current_time = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(|e| SignError::Generic(format!("Failed to get timestamp: {}", e)))?
+                    .as_secs();
+                let _token: BearerToken<()> =
+                    resolve_jwt_did(jwt, current_time, MAX_TOKEN_LIFETIME_SECS).map_err(|e| {
+                        SignError::Unauthorized(format!("JWT validation failed: {}", e))
+                    })?;
+
+                // Verify AccessDecision on-chain via light client
+                let light_client = self.app_state.acp_light_client.as_ref().ok_or_else(|| {
+                    SignError::AuthZ(
+                        "decision_id provided but ACP light client not configured".to_string(),
+                    )
+                })?;
+                let result = light_client
+                    .check_access_decision(decision_id)
+                    .await
+                    .map_err(|e| {
+                        SignError::AuthZ(format!("ACP light client error: {}", e))
+                    })?;
+                if !result.allowed {
+                    return Err(SignError::AuthZ(format!(
+                        "AccessDecision '{}' not authorized on-chain",
+                        decision_id,
+                    )));
+                }
+
+                // Look up ring info from bulletin
+                let ring_info = self
+                    .app_state
+                    .bulletin
+                    .read(BULLETIN_RING_NAMESPACE.to_string(), ring_id.clone())
+                    .await
+                    .map_err(|e| {
+                        SignError::VerificationFailed(format!(
+                            "Failed to read ring '{}': {}",
+                            ring_id, e
+                        ))
+                    })?;
+                let ring_payload =
+                    serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                        SignError::Deserialization(format!("Failed to parse ring payload: {}", e))
+                    })?;
+
+                let pub_poly_bytes =
+                    hex::decode(&ring_payload.public_polynomial).map_err(|e| {
+                        SignError::Deserialization(format!(
+                            "Failed to decode public polynomial hex: {}",
+                            e
+                        ))
+                    })?;
+                let pub_poly = <D::PubPoly>::from_bytes(&pub_poly_bytes).map_err(|e| {
+                    SignError::Deserialization(format!(
+                        "Failed to deserialize public polynomial: {}",
+                        e
+                    ))
+                })?;
+
+                (ring_payload.ring_pk, pub_poly, None, None)
+            }
         };
 
         // Deserialize ring public key and load DKG share from local storage
@@ -327,6 +495,8 @@ where
             let expected_context_key = match &context {
                 SignContext::Bulletin => "bulletin".to_string(),
                 SignContext::Policy { derivation_id, .. } => derivation_id.clone(),
+                SignContext::Authenticated { ring_id, .. } => format!("auth-{}", ring_id),
+                SignContext::AccessDecision { ring_id, .. } => format!("decision-{}", ring_id),
             };
             let state_bytes = self
                 .app_state
@@ -613,6 +783,7 @@ where
                 ));
                 (derivation, meta)
             }
+            SignContext::Authenticated { .. } | SignContext::AccessDecision { .. } => (None, None),
         };
 
         // =====================================================================

--- a/bin/orbis-node/src/sign/messages.rs
+++ b/bin/orbis-node/src/sign/messages.rs
@@ -7,11 +7,13 @@ use authz::sourcehub::ValidWindow;
 use bulletin::r#trait::KeyDerivation;
 use serde::{Deserialize, Serialize};
 
-/// Distinguishes the two signing pathways.
+/// Distinguishes the signing pathways.
 ///
 /// - `Bulletin`: message is a serialized `BulletinPost`; authorization is its existence on chain.
 ///   Signs from the root key (no derivation, no metadata).
 /// - `Policy`: policy-authorized derivation signing with JWT auth, mirrors the PRE flow.
+/// - `Authenticated`: JWT-verified signing with optional ACP policy check (utility service).
+/// - `AccessDecision`: JWT-verified signing with on-chain AccessDecision verification.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SignContext {
     /// Message bytes are a serialized `BulletinPost` verified against the chain.
@@ -33,6 +35,33 @@ pub enum SignContext {
         /// Carried here to avoid a redundant bulletin for the coordinator
         /// Peer nodes always re-fetch independently.
         key_derivation: KeyDerivation,
+    },
+    /// JWT-verified signing with optional ACP policy check via authz gRPC.
+    /// Each responder independently validates the JWT and checks ACP if policy fields are set.
+    /// Used by the UtilityService for direct threshold signing.
+    Authenticated {
+        /// Raw JWT string so each responder can verify independently
+        jwt: String,
+        /// Ring ID for lookup
+        ring_id: String,
+        /// ACP policy ID (empty = ACP not enforced, with warning)
+        policy_id: String,
+        /// ACP resource type
+        resource: String,
+        /// ACP object ID
+        object_id: String,
+        /// ACP permission/relationship to check
+        permission: String,
+    },
+    /// JWT-verified signing with on-chain AccessDecision verification via ACP light client.
+    /// Each responder independently validates the JWT and checks the decision via AcpLightClient.
+    AccessDecision {
+        /// Raw JWT string so each responder can verify independently
+        jwt: String,
+        /// Ring ID for lookup
+        ring_id: String,
+        /// The on-chain access decision ID to verify
+        decision_id: String,
     },
 }
 

--- a/bin/orbis-node/src/tests/concurrent.rs
+++ b/bin/orbis-node/src/tests/concurrent.rs
@@ -125,7 +125,7 @@ async fn setup_live_three_node_network(db_prefix: &str, base_port: u16) -> LiveT
 
         // Create signing key (stored in local_storage) and fund it via the faucet
         let signer =
-            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build())
+            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build(), None)
                 .expect("create node signing key");
         let public_address = signer.address();
 
@@ -176,13 +176,18 @@ async fn setup_live_three_node_network(db_prefix: &str, base_port: u16) -> LiveT
                 chain_rest: None,
                 chain_rpc: None,
                 denom: None,
+                data_dir: None,
                 metrics_addr: None,
                 loki_url: None,
+                hub_rpc: None,
+                hub_ws: None,
+                hub_chain_id: 9944,
             },
             network,
             local_storage,
             authz,
             bulletin,
+            acp_light_client: None,
         };
 
         let node = init_node(config).await.expect("init_node");

--- a/bin/orbis-node/src/tests/fault_injection.rs
+++ b/bin/orbis-node/src/tests/fault_injection.rs
@@ -129,7 +129,7 @@ async fn setup_fault_three_node_network(
         let local_storage = LocalStorageImpl::new(None, db_path.clone()).expect("local storage");
 
         let signer =
-            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build())
+            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build(), None)
                 .expect("create node signing key");
         let public_address = signer.address();
 
@@ -183,13 +183,18 @@ async fn setup_fault_three_node_network(
                 chain_rest: None,
                 chain_rpc: None,
                 denom: None,
+                data_dir: None,
                 metrics_addr: None,
                 loki_url: None,
+                hub_rpc: None,
+                hub_ws: None,
+                hub_chain_id: 9944,
             },
             network,
             local_storage,
             authz,
             bulletin,
+            acp_light_client: None,
         };
 
         let node = init_node(config).await.expect("init_node");

--- a/bin/orbis-node/src/tests/node.rs
+++ b/bin/orbis-node/src/tests/node.rs
@@ -48,14 +48,19 @@ async fn make_test_node_config(
             chain_rest: None,
             chain_rpc: None,
             denom: None,
+            data_dir: None,
             metrics_addr: None,
             loki_url: None,
+            hub_rpc: None,
+            hub_ws: None,
+            hub_chain_id: 9944,
         },
         network,
         local_storage: LocalStorageImpl::new(password, db_path.clone())
             .expect("Failed to create local storage"),
         authz,
         bulletin,
+        acp_light_client: None,
     };
     (config, db_path)
 }
@@ -333,7 +338,7 @@ fn test_create_and_store_node_key() {
     let config = ChainConfig::local();
 
     // First call should create a new key
-    let result = create_and_store_node_key(local_storage.clone(), config.clone());
+    let result = create_and_store_node_key(local_storage.clone(), config.clone(), None);
     assert!(
         result.is_ok(),
         "Should create key successfully: {:?}",
@@ -349,7 +354,7 @@ fn test_create_and_store_node_key() {
     );
 
     // Second call should return the same address (idempotent)
-    let result2 = create_and_store_node_key(local_storage.clone(), config);
+    let result2 = create_and_store_node_key(local_storage.clone(), config, None);
     assert!(result2.is_ok(), "Second call should succeed");
 
     let signer2 = result2.unwrap();

--- a/bin/orbis-node/src/utility/error.rs
+++ b/bin/orbis-node/src/utility/error.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+/// Utility service related errors
+#[derive(Error, Debug)]
+pub enum UtilityError {
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+
+    #[error("Ring not found: {0}")]
+    RingNotFound(String),
+
+    #[error("Deserialization error: {0}")]
+    Deserialization(String),
+
+    #[error("Crypto error: {0}")]
+    Crypto(String),
+
+    #[error("Signing error: {0}")]
+    Signing(String),
+
+    #[error("Unsupported algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+/// Convert UtilityError to tonic::Status for gRPC responses
+impl From<UtilityError> for tonic::Status {
+    fn from(error: UtilityError) -> Self {
+        match &error {
+            UtilityError::Unauthorized(_) => tonic::Status::unauthenticated(error.to_string()),
+            UtilityError::RingNotFound(_) => tonic::Status::not_found(error.to_string()),
+            UtilityError::Deserialization(_) => tonic::Status::invalid_argument(error.to_string()),
+            UtilityError::UnsupportedAlgorithm(_) => {
+                tonic::Status::invalid_argument(error.to_string())
+            }
+            UtilityError::Crypto(_) | UtilityError::Signing(_) | UtilityError::Internal(_) => {
+                tonic::Status::internal(error.to_string())
+            }
+        }
+    }
+}

--- a/bin/orbis-node/src/utility/mod.rs
+++ b/bin/orbis-node/src/utility/mod.rs
@@ -1,0 +1,4 @@
+pub mod error;
+pub mod service;
+
+pub use service::UtilityServiceImpl;

--- a/bin/orbis-node/src/utility/service.rs
+++ b/bin/orbis-node/src/utility/service.rs
@@ -1,0 +1,365 @@
+use crate::app_state::AppState;
+use crate::constants::{BULLETIN_RING_NAMESPACE, MAX_TOKEN_LIFETIME_SECS};
+use crate::helpers::helpers::{validate_all_peer_ids, RingConfig};
+use crate::sign::coordinator::{SignCoordinator, SignResponse};
+use crate::sign::messages::SignContext;
+use crate::utility::error::UtilityError;
+use authn::{extract_bearer_token, resolve_jwt_did, BearerToken, SignClaims};
+use authz::sourcehub::AccessCheckRequest;
+use bulletin::r#trait::RingPayload;
+use crypto::r#trait::{CryptoDeserialize, CryptoSerialize, Dkg, ThresholdDealer, ThresholdSigner};
+use crypto::PreImpl as ThresholdDealerNode;
+use proto::utility_service::{
+    utility_service_server::UtilityService, DerivePublicKeyRequest, DerivePublicKeyResponse,
+    SignAlgorithm, SignRequest, SignResponse as ProtoSignResponse,
+};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tonic::{Request, Response, Status};
+
+/// Map a ThresholdSigner::name() string to the proto SignAlgorithm enum.
+fn signer_algorithm<S: ThresholdSigner>() -> SignAlgorithm {
+    match S::name().as_str() {
+        "threshold-bls-g2" => SignAlgorithm::Bls,
+        "threshold-frost-decaf377" => SignAlgorithm::FrostDecaf377,
+        _ => SignAlgorithm::Unspecified,
+    }
+}
+
+/// Implementation of the UtilityService
+///
+/// Provides two RPCs:
+/// - DerivePublicKey: derive a public key from a ring's master PK + label (unauthenticated)
+/// - Sign: perform T-of-N threshold signing (authenticated)
+#[derive(Debug)]
+pub struct UtilityServiceImpl<D, S>
+where
+    D: Dkg + Clone + 'static,
+    S: ThresholdSigner,
+{
+    pub state: AppState<D>,
+    _phantom: std::marker::PhantomData<S>,
+}
+
+impl<D, S> UtilityServiceImpl<D, S>
+where
+    D: Dkg + Clone + 'static,
+    S: ThresholdSigner,
+{
+    pub fn new(state: AppState<D>) -> Self {
+        Self {
+            state,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl<D, S> UtilityService for UtilityServiceImpl<D, S>
+where
+    D: Dkg<ShareValue = crypto::ScalarField, PublicKey = crypto::GroupAffine>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    S: ThresholdSigner<
+            ShareValue = crypto::ScalarField,
+            PublicKey = crypto::GroupAffine,
+            DistKeyShare = crypto::r#trait::DistKeyShare<crypto::ScalarField>,
+            PubPoly = D::PubPoly,
+            Signature = crypto::SignaturePoint,
+            SigShare = crypto::r#trait::PubShare<crypto::SigShareInner>,
+        > + Send
+        + Sync
+        + 'static,
+{
+    #[tracing::instrument(skip_all, fields(request))]
+    async fn derive_public_key(
+        &self,
+        request: Request<DerivePublicKeyRequest>,
+    ) -> Result<Response<DerivePublicKeyResponse>, Status> {
+        let req = request.into_inner();
+
+        tracing::info!(
+            ring_id = %req.ring_id,
+            derivation_len = req.derivation.len(),
+            "DerivePublicKey request"
+        );
+
+        // 1. Read ring info from bulletin
+        let ring_info = self
+            .state
+            .bulletin
+            .read(BULLETIN_RING_NAMESPACE.to_string(), req.ring_id.clone())
+            .await
+            .map_err(|e| {
+                UtilityError::RingNotFound(format!(
+                    "Failed to read ring '{}': {}",
+                    req.ring_id, e
+                ))
+            })?;
+
+        let ring_payload =
+            serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                UtilityError::Deserialization(format!("Failed to parse ring payload: {}", e))
+            })?;
+
+        // 2. Parse ring_pk from hex -> G1Affine
+        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk).map_err(|e| {
+            UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e))
+        })?;
+        let ring_pk = <D::PublicKey>::from_bytes(&ring_pk_bytes).map_err(|e| {
+            UtilityError::Deserialization(format!("Invalid ring_pk curve point: {}", e))
+        })?;
+
+        // 3. Derive public key
+        let derived_pk =
+            ThresholdDealerNode::derive_public_key(&ring_pk, &req.derivation).map_err(|e| {
+                UtilityError::Crypto(format!("Failed to derive public key: {}", e))
+            })?;
+
+        // 4. Serialize derived key
+        let derived_pk_bytes = CryptoSerialize::to_bytes(&derived_pk).map_err(|e| {
+            UtilityError::Crypto(format!("Failed to serialize derived public key: {}", e))
+        })?;
+
+        Ok(Response::new(DerivePublicKeyResponse {
+            public_key: derived_pk_bytes,
+            algorithm: signer_algorithm::<S>().into(),
+        }))
+    }
+
+    #[tracing::instrument(skip_all, fields(request))]
+    async fn sign(
+        &self,
+        request: Request<SignRequest>,
+    ) -> Result<Response<ProtoSignResponse>, Status> {
+        let current_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Status::internal(format!("Failed to get timestamp: {}", e)))?
+            .as_secs();
+
+        // 1. Authenticate: Extract and validate JWT
+        let token_str = extract_bearer_token(&request)
+            .map_err(|e| UtilityError::Unauthorized(e.to_string()))?;
+        let jwt_string = token_str.to_string();
+        let token: BearerToken<SignClaims> = resolve_jwt_did(token_str, current_time, MAX_TOKEN_LIFETIME_SECS)
+            .map_err(|e| {
+                UtilityError::Unauthorized(format!("JWT validation failed: {}", e))
+            })?;
+
+        let req = request.into_inner();
+
+        // 2. Algorithm guard
+        let ring_algorithm = signer_algorithm::<S>();
+        let requested = SignAlgorithm::try_from(req.algorithm).unwrap_or(SignAlgorithm::Unspecified);
+        if requested != SignAlgorithm::Unspecified && requested != ring_algorithm {
+            return Err(UtilityError::UnsupportedAlgorithm(format!(
+                "requested algorithm {:?} but ring uses {:?}",
+                requested.as_str_name(),
+                ring_algorithm.as_str_name(),
+            ))
+            .into());
+        }
+
+        // 3. Validate JWT claims match request
+        if token.claims.ring_id != req.ring_id {
+            return Err(UtilityError::Unauthorized(format!(
+                "Token ring_id '{}' does not match request ring_id '{}'",
+                token.claims.ring_id, req.ring_id
+            ))
+            .into());
+        }
+        if token.claims.message != req.message {
+            return Err(
+                UtilityError::Unauthorized("Token message does not match request".to_string())
+                    .into(),
+            );
+        }
+        let req_derivation = if req.derivation.is_empty() {
+            None
+        } else {
+            Some(req.derivation.clone())
+        };
+        if token.claims.derivation != req_derivation {
+            return Err(UtilityError::Unauthorized(
+                "Token derivation does not match request".to_string(),
+            )
+            .into());
+        }
+
+        // Mutual exclusivity: decision_id and policy_id cannot both be set
+        if !req.decision_id.is_empty() && !req.policy_id.is_empty() {
+            return Err(UtilityError::Unauthorized(
+                "decision_id and policy_id are mutually exclusive".to_string(),
+            )
+            .into());
+        }
+
+        // ACP authorization: three-way branch
+        if !req.decision_id.is_empty() {
+            let light_client = self.state.acp_light_client.as_ref().ok_or_else(|| {
+                UtilityError::Signing(
+                    "decision_id provided but ACP light client not configured (--hub-rpc/--hub-ws)"
+                        .to_string(),
+                )
+            })?;
+            let result = light_client
+                .check_access_decision(&req.decision_id)
+                .await
+                .map_err(|e| {
+                    UtilityError::Signing(format!("ACP light client error: {}", e))
+                })?;
+            if !result.allowed {
+                return Err(UtilityError::Unauthorized(format!(
+                    "AccessDecision '{}' not authorized on-chain",
+                    req.decision_id,
+                ))
+                .into());
+            }
+            tracing::info!(
+                decision_id = %req.decision_id,
+                verified_at_height = result.verified_at_height,
+                "AccessDecision verified via light client"
+            );
+        } else if !req.policy_id.is_empty() {
+            let permission_bytes = AccessCheckRequest::new(
+                req.policy_id.clone(),
+                req.resource.clone(),
+                req.object_id.clone(),
+                req.permission.clone(),
+                None,
+                None,
+                None,
+            )
+            .to_bytes()
+            .map_err(|e| {
+                UtilityError::Signing(format!("Error formatting access request: {}", e))
+            })?;
+            let authorized = self
+                .state
+                .authz
+                .check(permission_bytes, &token.issuer_id)
+                .await
+                .map_err(|e| UtilityError::Signing(format!("ACP authorization failed: {}", e)))?;
+            if !authorized {
+                return Err(UtilityError::Unauthorized(format!(
+                    "ACP denied: {} not authorized for {}/{}/{}",
+                    token.issuer_id, req.resource, req.object_id, req.permission,
+                ))
+                .into());
+            }
+        } else {
+            tracing::warn!(
+                ring_id = %req.ring_id,
+                issuer = %token.issuer_id,
+                "Sign request without ACP fields — authorization not enforced"
+            );
+        }
+
+        tracing::info!(
+            ring_id = %req.ring_id,
+            message_len = req.message.len(),
+            algorithm = %ring_algorithm.as_str_name(),
+            issuer = %token.issuer_id,
+            "Authenticated Sign request"
+        );
+
+        // 4. Read ring info from bulletin
+        let ring_info = self
+            .state
+            .bulletin
+            .read(BULLETIN_RING_NAMESPACE.to_string(), req.ring_id.clone())
+            .await
+            .map_err(|e| {
+                UtilityError::RingNotFound(format!(
+                    "Failed to read ring '{}': {}",
+                    req.ring_id, e
+                ))
+            })?;
+
+        let ring_payload =
+            serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                UtilityError::Deserialization(format!("Failed to parse ring payload: {}", e))
+            })?;
+
+        // 5. Compute the public key that will verify this signature
+        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk).map_err(|e| {
+            UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e))
+        })?;
+        let verification_pk = if req.derivation.is_empty() {
+            ring_pk_bytes.clone()
+        } else {
+            let ring_pk = <D::PublicKey>::from_bytes(&ring_pk_bytes).map_err(|e| {
+                UtilityError::Deserialization(format!("Invalid ring_pk curve point: {}", e))
+            })?;
+            let derived = ThresholdDealerNode::derive_public_key(&ring_pk, &req.derivation)
+                .map_err(|e| UtilityError::Crypto(format!("Failed to derive public key: {}", e)))?;
+            CryptoSerialize::to_bytes(&derived)
+                .map_err(|e| UtilityError::Crypto(format!("Failed to serialize public key: {}", e)))?
+        };
+
+        // Validate peers
+        if ring_payload.peer_ids.is_empty() {
+            return Err(UtilityError::Signing("No peer IDs found for ring".to_string()).into());
+        }
+        if let Err((invalid_peer_id, validation_error)) =
+            validate_all_peer_ids(&ring_payload.peer_ids)
+        {
+            return Err(UtilityError::Signing(format!(
+                "Invalid peer ID '{}': {}",
+                invalid_peer_id, validation_error
+            ))
+            .into());
+        }
+
+        // 6. Initiate threshold signing
+        let ring = RingConfig {
+            ring_pk_bytes,
+            peer_ids: ring_payload.peer_ids.clone(),
+            threshold: ring_payload.threshold as usize,
+            total_participants: ring_payload.peer_ids.len(),
+            public_polynomial_hex: ring_payload.public_polynomial,
+        };
+
+        let context = if !req.decision_id.is_empty() {
+            SignContext::AccessDecision {
+                jwt: jwt_string,
+                ring_id: req.ring_id.clone(),
+                decision_id: req.decision_id.clone(),
+            }
+        } else {
+            SignContext::Authenticated {
+                jwt: jwt_string,
+                ring_id: req.ring_id.clone(),
+                policy_id: req.policy_id.clone(),
+                resource: req.resource.clone(),
+                object_id: req.object_id.clone(),
+                permission: req.permission.clone(),
+            }
+        };
+
+        let request_id = rand::random::<u64>().to_string();
+        let coordinator = SignCoordinator::<D, S>::new(Arc::new(self.state.clone()));
+        let response_bytes = coordinator
+            .initiate_signing(request_id, ring, req.message, context)
+            .await
+            .map_err(|e| UtilityError::Signing(format!("Signing failed: {}", e)))?;
+
+        let sign_response: SignResponse =
+            serde_json::from_slice(&response_bytes).map_err(|e| {
+                UtilityError::Signing(format!("Failed to parse sign response: {}", e))
+            })?;
+
+        let signature_bytes = hex::decode(&sign_response.signature).map_err(|e| {
+            UtilityError::Signing(format!("Failed to decode signature hex: {}", e))
+        })?;
+
+        Ok(Response::new(ProtoSignResponse {
+            signature: signature_bytes,
+            algorithm: ring_algorithm.into(),
+            public_key: verification_pk,
+            metadata: std::collections::HashMap::new(),
+        }))
+    }
+}

--- a/crates/authn/src/jwt_builder.rs
+++ b/crates/authn/src/jwt_builder.rs
@@ -129,6 +129,34 @@ impl JwtSigner {
             namespace: namespace.to_string(),
             derivation_id: derivation_id.to_string(),
             message: message.clone(),
+            ..Default::default()
+        };
+        self.sign(claims, Duration::from_hours(1))
+    }
+
+    /// Create a JWT with Sign claims for the UtilityService pathway.
+    ///
+    /// Uses ring_id + optional derivation + ACP fields instead of namespace/derivation_id.
+    pub fn create_utility_sign_jwt(
+        &self,
+        ring_id: &str,
+        message: Vec<u8>,
+        derivation: Option<Vec<u8>>,
+        policy_id: &str,
+        resource: &str,
+        object_id: &str,
+        permission: &str,
+    ) -> Result<String> {
+        let claims = SignClaims {
+            ring_id: ring_id.to_string(),
+            message,
+            derivation,
+            policy_id: policy_id.to_string(),
+            resource: resource.to_string(),
+            object_id: object_id.to_string(),
+            permission: permission.to_string(),
+            decision_id: String::new(),
+            ..Default::default()
         };
         self.sign(claims, Duration::from_hours(1))
     }

--- a/crates/authn/src/lib.rs
+++ b/crates/authn/src/lib.rs
@@ -12,6 +12,9 @@ pub use jwt_builder::{
     add_auth_header, create_authenticated_request, extract_bearer_token, JwtSigner,
 };
 
+/// Re-export jwt_simple Duration for callers that need to create JWTs
+pub use jwt_simple::prelude::Duration as JwtDuration;
+
 #[cfg(test)]
 mod tests;
 
@@ -51,15 +54,42 @@ pub struct PreClaims {
     pub salt: Option<String>,
 }
 
-/// Claims for Sign (threshold signing) endpoints
+/// Claims for Sign (threshold signing) endpoints.
+///
+/// Used by both the SignService (policy pathway: namespace + derivation_id) and the
+/// UtilityService (direct pathway: ring_id + optional ACP fields). Fields not relevant
+/// to a particular pathway default to empty/None.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct SignClaims {
-    /// Namespace where the key derivation object is stored
+    /// Namespace where the key derivation object is stored (SignService pathway)
+    #[serde(default)]
     pub namespace: String,
-    /// Object ID of the key derivation entry on the bulletin
+    /// Object ID of the key derivation entry on the bulletin (SignService pathway)
+    #[serde(default)]
     pub derivation_id: String,
     /// Message to sign
     pub message: Vec<u8>,
+    /// Ring ID to sign with (UtilityService pathway)
+    #[serde(default)]
+    pub ring_id: String,
+    /// Optional derivation path (UtilityService pathway)
+    #[serde(default)]
+    pub derivation: Option<Vec<u8>>,
+    /// ACP policy ID (empty = ACP not enforced)
+    #[serde(default)]
+    pub policy_id: String,
+    /// ACP resource type
+    #[serde(default)]
+    pub resource: String,
+    /// ACP object ID
+    #[serde(default)]
+    pub object_id: String,
+    /// ACP permission/relationship to check
+    #[serde(default)]
+    pub permission: String,
+    /// AccessDecision ID (mutually exclusive with policy_id)
+    #[serde(default)]
+    pub decision_id: String,
 }
 
 /// Claims for DKG endpoints

--- a/crates/bulletin/Cargo.toml
+++ b/crates/bulletin/Cargo.toml
@@ -16,10 +16,34 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 backoff = { version = "0.4", features = ["tokio"] }
 
+# Hub.rs EVM bulletin dependencies (optional, gated behind hubrs feature)
+alloy-primitives = { workspace = true, optional = true }
+alloy-consensus = { workspace = true, optional = true }
+alloy-eips = { workspace = true, optional = true }
+alloy-signer = { workspace = true, optional = true }
+alloy-signer-local = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+
 [features]
 default = ["sourcehub"]
 sourcehub = []
 dummy = []
+hubrs = [
+    "dep:alloy-primitives",
+    "dep:alloy-consensus",
+    "dep:alloy-eips",
+    "dep:alloy-signer",
+    "dep:alloy-signer-local",
+    "dep:alloy-sol-types",
+    "dep:k256",
+    "dep:base64",
+    "dep:reqwest",
+    "dep:tokio",
+]
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/crates/bulletin/src/hubrs/abi.rs
+++ b/crates/bulletin/src/hubrs/abi.rs
@@ -1,0 +1,32 @@
+use alloy_sol_types::sol;
+
+// IBulletin precompile address on hub.rs chain
+pub const BULLETIN_PRECOMPILE_ADDRESS: [u8; 20] = {
+    let mut addr = [0u8; 20];
+    addr[18] = 0x08;
+    addr[19] = 0x11;
+    addr
+};
+
+sol! {
+    /// IBulletin precompile interface at address 0x0811 on hub.rs
+    #[derive(Debug)]
+    interface IBulletin {
+        /// Register a new namespace on the bulletin board
+        function registerNamespace(string memory namespace) external;
+
+        /// Create a post in a namespace with payload, proof, and optional artifact
+        function createPost(
+            string memory namespace,
+            bytes memory payload,
+            bytes memory proof,
+            string memory artifact
+        ) external;
+
+        /// Read a post by namespace and ID, returns JSON-encoded post bytes
+        function getPost(
+            string memory namespace,
+            string memory id
+        ) external view returns (bytes memory);
+    }
+}

--- a/crates/bulletin/src/hubrs/client.rs
+++ b/crates/bulletin/src/hubrs/client.rs
@@ -1,0 +1,163 @@
+use alloy_primitives::Address;
+use serde_json::{json, Value};
+
+use crate::error::{BulletinError, Result};
+
+use super::signer::EvmSigner;
+use super::types::TransactionReceipt;
+
+/// Lightweight EVM JSON-RPC client for hub.rs precompile interactions
+pub struct EvmClient {
+    http: reqwest::Client,
+    rpc_url: String,
+    signer: Option<EvmSigner>,
+}
+
+impl EvmClient {
+    pub fn new(rpc_url: String, signer: Option<EvmSigner>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            rpc_url,
+            signer,
+        }
+    }
+
+    /// Perform a read-only eth_call
+    pub async fn eth_call(&self, to: Address, calldata: Vec<u8>) -> Result<Vec<u8>> {
+        let result = self
+            .rpc_request(
+                "eth_call",
+                json!([
+                    {
+                        "to": format!("{:?}", to),
+                        "data": format!("0x{}", hex::encode(&calldata)),
+                    },
+                    "latest"
+                ]),
+            )
+            .await?;
+
+        let hex_str = result
+            .as_str()
+            .ok_or_else(|| BulletinError::ChainError("eth_call returned non-string".into()))?;
+
+        let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+        hex::decode(hex_str)
+            .map_err(|e| BulletinError::ChainError(format!("Failed to decode eth_call result: {}", e)))
+    }
+
+    /// Get the transaction count (nonce) for an address
+    pub async fn get_nonce(&self, address: Address) -> Result<u64> {
+        let result = self
+            .rpc_request(
+                "eth_getTransactionCount",
+                json!([format!("{:?}", address), "latest"]),
+            )
+            .await?;
+
+        let hex_str = result
+            .as_str()
+            .ok_or_else(|| BulletinError::ChainError("nonce returned non-string".into()))?;
+
+        let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+        u64::from_str_radix(hex_str, 16)
+            .map_err(|e| BulletinError::ChainError(format!("Failed to parse nonce: {}", e)))
+    }
+
+    /// Send a raw signed transaction
+    pub async fn send_raw_transaction(&self, raw_tx: &[u8]) -> Result<String> {
+        let result = self
+            .rpc_request(
+                "eth_sendRawTransaction",
+                json!([format!("0x{}", hex::encode(raw_tx))]),
+            )
+            .await?;
+
+        result
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| BulletinError::ChainError("sendRawTransaction returned non-string".into()))
+    }
+
+    /// Get the transaction receipt
+    pub async fn get_transaction_receipt(&self, tx_hash: &str) -> Result<Option<TransactionReceipt>> {
+        let result = self
+            .rpc_request("eth_getTransactionReceipt", json!([tx_hash]))
+            .await?;
+
+        if result.is_null() {
+            return Ok(None);
+        }
+
+        serde_json::from_value(result)
+            .map(Some)
+            .map_err(|e| BulletinError::ChainError(format!("Failed to parse receipt: {}", e)))
+    }
+
+    /// Wait for a transaction receipt with polling
+    pub async fn wait_for_receipt(&self, tx_hash: &str) -> Result<TransactionReceipt> {
+        for _ in 0..30 {
+            if let Some(receipt) = self.get_transaction_receipt(tx_hash).await? {
+                return Ok(receipt);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+        Err(BulletinError::ChainError(format!(
+            "Timeout waiting for receipt of tx {}",
+            tx_hash
+        )))
+    }
+
+    /// Send a precompile transaction: fetch nonce, sign, send, wait for receipt
+    pub async fn send_precompile_tx(&self, to: Address, calldata: Vec<u8>) -> Result<TransactionReceipt> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or_else(|| BulletinError::ChainError("No signer configured for write operation".into()))?;
+
+        let nonce = self.get_nonce(signer.address()).await?;
+        let raw_tx = signer.sign_tx(to, calldata, nonce)?;
+        let tx_hash = self.send_raw_transaction(&raw_tx).await?;
+        let receipt = self.wait_for_receipt(&tx_hash).await?;
+
+        if !receipt.succeeded() {
+            return Err(BulletinError::ChainError(format!(
+                "Transaction {} reverted",
+                tx_hash
+            )));
+        }
+
+        Ok(receipt)
+    }
+
+    /// Make a JSON-RPC request and return the result field
+    async fn rpc_request(&self, method: &str, params: Value) -> Result<Value> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": 1,
+        });
+
+        let response = self
+            .http
+            .post(&self.rpc_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| BulletinError::ChainError(format!("RPC request failed: {}", e)))?;
+
+        let json: Value = response
+            .json()
+            .await
+            .map_err(|e| BulletinError::ChainError(format!("Failed to parse RPC response: {}", e)))?;
+
+        if let Some(error) = json.get("error") {
+            return Err(BulletinError::ChainError(format!("RPC error: {}", error)));
+        }
+
+        json.get("result")
+            .cloned()
+            .ok_or_else(|| BulletinError::ChainError("RPC response missing 'result' field".into()))
+    }
+}

--- a/crates/bulletin/src/hubrs/mod.rs
+++ b/crates/bulletin/src/hubrs/mod.rs
@@ -1,0 +1,157 @@
+mod abi;
+mod client;
+pub mod signer;
+mod types;
+
+use alloy_primitives::Address;
+use alloy_sol_types::SolCall;
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::error::{BulletinError, Result};
+use crate::r#trait::{Bulletin, BulletinPost};
+
+use abi::{IBulletin, BULLETIN_PRECOMPILE_ADDRESS};
+use client::EvmClient;
+use types::HubPost;
+
+#[cfg(test)]
+mod tests;
+
+/// Configuration for connecting to a hub.rs node
+pub struct HubRsConfig {
+    pub rpc_url: String,
+    pub chain_id: u64,
+}
+
+/// Hub.rs bulletin client using EVM precompiles
+pub struct HubRsBulletin {
+    client: EvmClient,
+    precompile_addr: Address,
+}
+
+#[async_trait]
+impl Bulletin for HubRsBulletin {
+    async fn register(&self, namespace: String) -> Result<()> {
+        let calldata = IBulletin::registerNamespaceCall {
+            namespace,
+        }
+        .abi_encode();
+
+        self.client
+            .send_precompile_tx(self.precompile_addr, calldata)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn post(
+        &self,
+        namespace: String,
+        payload: Vec<u8>,
+        proof: Vec<u8>,
+        artifact: Option<String>,
+    ) -> Result<()> {
+        let calldata = IBulletin::createPostCall {
+            namespace,
+            payload: payload.into(),
+            proof: proof.into(),
+            artifact: artifact.unwrap_or_default(),
+        }
+        .abi_encode();
+
+        self.client
+            .send_precompile_tx(self.precompile_addr, calldata)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn read(&self, namespace: String, id: String) -> Result<BulletinPost> {
+        // Strip "bulletin/" prefix if present for robustness
+        let ns = namespace
+            .strip_prefix("bulletin/")
+            .unwrap_or(&namespace)
+            .to_string();
+
+        let calldata = IBulletin::getPostCall {
+            namespace: ns.clone(),
+            id: id.clone(),
+        }
+        .abi_encode();
+
+        let result_bytes = self
+            .client
+            .eth_call(self.precompile_addr, calldata)
+            .await?;
+
+        // ABI-decode the return value: getPost returns (bytes memory)
+        let decoded = IBulletin::getPostCall::abi_decode_returns(&result_bytes)
+            .map_err(|e| {
+                BulletinError::ChainError(format!("Failed to ABI-decode getPost response: {}", e))
+            })?;
+
+        let json_bytes: &[u8] = &decoded.0;
+
+        if json_bytes.is_empty() {
+            return Err(BulletinError::NotFound {
+                namespace: ns,
+                id,
+            });
+        }
+
+        let hub_post: HubPost = serde_json::from_slice(json_bytes).map_err(|e| {
+            BulletinError::ParseError(format!(
+                "Failed to parse hub.rs post JSON: {}",
+                e
+            ))
+        })?;
+
+        Ok(BulletinPost {
+            id: hub_post.id,
+            namespace: hub_post.namespace,
+            payload: hub_post.payload,
+            proof: hub_post.proof,
+        })
+    }
+
+    fn get_post_id(&self, namespace: &str, payload: &[u8]) -> Result<String> {
+        Ok(Self::compute_post_id(namespace, payload))
+    }
+}
+
+impl HubRsBulletin {
+    pub fn name() -> String {
+        "bulletin/hubrs".to_string()
+    }
+
+    /// Create a read-only client (no signing capability)
+    pub fn new(config: HubRsConfig) -> Result<Self> {
+        let precompile_addr = Address::from(BULLETIN_PRECOMPILE_ADDRESS);
+        let client = EvmClient::new(config.rpc_url, None);
+        Ok(Self {
+            client,
+            precompile_addr,
+        })
+    }
+
+    /// Create a client with signing capability for write operations
+    pub fn with_signer(config: HubRsConfig, hex_key: &str) -> Result<Self> {
+        let precompile_addr = Address::from(BULLETIN_PRECOMPILE_ADDRESS);
+        let signer = signer::EvmSigner::from_hex(hex_key, config.chain_id)?;
+        let client = EvmClient::new(config.rpc_url, Some(signer));
+        Ok(Self {
+            client,
+            precompile_addr,
+        })
+    }
+
+    /// Compute deterministic post ID from namespace and payload.
+    /// Same as SourceHub: hex(SHA256(namespace_bytes || payload))
+    pub fn compute_post_id(namespace: &str, payload: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(namespace.as_bytes());
+        hasher.update(payload);
+        hex::encode(hasher.finalize())
+    }
+}

--- a/crates/bulletin/src/hubrs/signer.rs
+++ b/crates/bulletin/src/hubrs/signer.rs
@@ -1,0 +1,52 @@
+use alloy_consensus::{SignableTransaction, TxLegacy};
+use alloy_eips::eip2718::Encodable2718;
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+
+use crate::error::{BulletinError, Result};
+
+/// EVM transaction signer wrapping a secp256k1 private key
+pub struct EvmSigner {
+    signer: PrivateKeySigner,
+    chain_id: u64,
+}
+
+impl EvmSigner {
+    /// Create a signer from a hex-encoded private key and chain ID
+    pub fn from_hex(hex_key: &str, chain_id: u64) -> Result<Self> {
+        let key_bytes =
+            hex::decode(hex_key).map_err(|e| BulletinError::ChainError(format!("Invalid hex key: {}", e)))?;
+        let signing_key = k256::ecdsa::SigningKey::from_slice(&key_bytes)
+            .map_err(|e| BulletinError::ChainError(format!("Invalid private key: {}", e)))?;
+        let signer = PrivateKeySigner::from_signing_key(signing_key);
+        Ok(Self { signer, chain_id })
+    }
+
+    /// Get the EVM address of this signer
+    pub fn address(&self) -> Address {
+        self.signer.address()
+    }
+
+    /// Sign a legacy transaction and return EIP-2718 encoded bytes
+    pub fn sign_tx(&self, to: Address, calldata: Vec<u8>, nonce: u64) -> Result<Vec<u8>> {
+        let tx = TxLegacy {
+            chain_id: Some(self.chain_id),
+            nonce,
+            gas_price: 0,
+            gas_limit: 10_000_000,
+            to: TxKind::Call(to),
+            value: U256::ZERO,
+            input: calldata.into(),
+        };
+
+        let sig_hash = tx.signature_hash();
+        let sig = self
+            .signer
+            .sign_hash_sync(&sig_hash)
+            .map_err(|e| BulletinError::ChainError(format!("Failed to sign transaction: {}", e)))?;
+
+        let signed_tx = tx.into_signed(sig);
+        Ok(signed_tx.encoded_2718())
+    }
+}

--- a/crates/bulletin/src/hubrs/tests.rs
+++ b/crates/bulletin/src/hubrs/tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+use alloy_sol_types::SolCall;
+
+#[test]
+fn test_compute_post_id() {
+    // Same computation as SourceHub and Dummy: SHA256(namespace || payload)
+    let namespace = "bulletin/orbis";
+    let payload = b"hello world";
+    let id = HubRsBulletin::compute_post_id(namespace, payload);
+
+    // Verify deterministic
+    let id2 = HubRsBulletin::compute_post_id(namespace, payload);
+    assert_eq!(id, id2);
+
+    // Verify it's a valid hex-encoded SHA256 (64 chars)
+    assert_eq!(id.len(), 64);
+    assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[test]
+fn test_name() {
+    assert_eq!(HubRsBulletin::name(), "bulletin/hubrs");
+}
+
+#[test]
+fn test_register_namespace_abi_encoding() {
+    let call = abi::IBulletin::registerNamespaceCall {
+        namespace: "orbis".to_string(),
+    };
+    let encoded = call.abi_encode();
+
+    // Should have 4-byte selector + ABI-encoded string
+    assert!(encoded.len() > 4);
+
+    // Roundtrip decode
+    let decoded = abi::IBulletin::registerNamespaceCall::abi_decode(&encoded).unwrap();
+    assert_eq!(decoded.namespace, "orbis");
+}
+
+#[test]
+fn test_create_post_abi_encoding() {
+    let call = abi::IBulletin::createPostCall {
+        namespace: "orbis".to_string(),
+        payload: vec![1, 2, 3].into(),
+        proof: vec![4, 5, 6].into(),
+        artifact: "".to_string(),
+    };
+    let encoded = call.abi_encode();
+    assert!(encoded.len() > 4);
+
+    let decoded = abi::IBulletin::createPostCall::abi_decode(&encoded).unwrap();
+    assert_eq!(decoded.namespace, "orbis");
+    assert_eq!(decoded.payload.as_ref(), &[1, 2, 3]);
+    assert_eq!(decoded.proof.as_ref(), &[4, 5, 6]);
+    assert_eq!(decoded.artifact, "");
+}
+
+#[test]
+fn test_get_post_abi_encoding() {
+    let call = abi::IBulletin::getPostCall {
+        namespace: "orbis".to_string(),
+        id: "abc123".to_string(),
+    };
+    let encoded = call.abi_encode();
+    assert!(encoded.len() > 4);
+
+    let decoded = abi::IBulletin::getPostCall::abi_decode(&encoded).unwrap();
+    assert_eq!(decoded.namespace, "orbis");
+    assert_eq!(decoded.id, "abc123");
+}
+
+#[test]
+fn test_precompile_address() {
+    let addr = Address::from(abi::BULLETIN_PRECOMPILE_ADDRESS);
+    assert_eq!(format!("{:?}", addr), "0x0000000000000000000000000000000000000811");
+}

--- a/crates/bulletin/src/hubrs/types.rs
+++ b/crates/bulletin/src/hubrs/types.rs
@@ -1,0 +1,90 @@
+use serde::Deserialize;
+
+/// Transaction receipt from JSON-RPC eth_getTransactionReceipt
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct TransactionReceipt {
+    /// Status: 0x1 for success, 0x0 for failure
+    pub status: String,
+    /// Transaction hash
+    pub transaction_hash: String,
+    /// Block number (hex)
+    pub block_number: Option<String>,
+    /// Gas used (hex)
+    pub gas_used: Option<String>,
+}
+
+impl TransactionReceipt {
+    pub fn succeeded(&self) -> bool {
+        self.status == "0x1"
+    }
+}
+
+/// Post structure matching hub.rs bulletin module JSON output.
+///
+/// Hub.rs may return `payload` and `proof` as either a base64 string
+/// or a JSON byte array (e.g. `[123, 34, ...]`). The custom deserializer
+/// handles both formats, storing the raw bytes.
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct HubPost {
+    pub id: String,
+    pub namespace: String,
+    #[serde(default)]
+    pub creator_did: String,
+    #[serde(deserialize_with = "deserialize_bytes_or_string")]
+    pub payload: Vec<u8>,
+    #[serde(default, deserialize_with = "deserialize_bytes_or_string_opt")]
+    pub proof: Vec<u8>,
+}
+
+fn deserialize_bytes_or_string<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct BytesOrString;
+
+    impl<'de> de::Visitor<'de> for BytesOrString {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a string or byte array")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> Result<Vec<u8>, E> {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(v)
+                .unwrap_or_else(|_| v.as_bytes().to_vec())
+                .pipe(Ok)
+        }
+
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<u8>, A::Error> {
+            let mut bytes = Vec::new();
+            while let Some(b) = seq.next_element::<u8>()? {
+                bytes.push(b);
+            }
+            Ok(bytes)
+        }
+    }
+
+    deserializer.deserialize_any(BytesOrString)
+}
+
+fn deserialize_bytes_or_string_opt<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_bytes_or_string(deserializer)
+}
+
+trait Pipe: Sized {
+    fn pipe<T>(self, f: impl FnOnce(Self) -> T) -> T {
+        f(self)
+    }
+}
+
+impl<T> Pipe for T {}

--- a/crates/bulletin/src/lib.rs
+++ b/crates/bulletin/src/lib.rs
@@ -4,6 +4,9 @@ pub mod r#trait;
 #[cfg(feature = "sourcehub")]
 pub mod sourcehub;
 
+#[cfg(feature = "hubrs")]
+pub mod hubrs;
+
 // Export dummy for testing anyways
 pub mod dummy;
 
@@ -11,8 +14,16 @@ pub mod dummy;
 #[cfg(all(feature = "sourcehub", feature = "dummy"))]
 compile_error!("Features 'sourcehub' and 'dummy' are mutually exclusive. Use --no-default-features to disable the default backend.");
 
+#[cfg(all(feature = "sourcehub", feature = "hubrs"))]
+compile_error!("Features 'sourcehub' and 'hubrs' are mutually exclusive. Use --no-default-features to disable the default backend.");
+
+#[cfg(all(feature = "dummy", feature = "hubrs"))]
+compile_error!("Features 'dummy' and 'hubrs' are mutually exclusive. Use --no-default-features to disable the default backend.");
+
 // Export the selected implementation
 #[cfg(feature = "dummy")]
 pub use dummy::DummyBulletin as BulletinImpl;
 #[cfg(feature = "sourcehub")]
 pub use sourcehub::SourceHubBulletin as BulletinImpl;
+#[cfg(feature = "hubrs")]
+pub use hubrs::HubRsBulletin as BulletinImpl;

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -5,6 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/info_service.proto",
         "proto/store_secret_service.proto",
         "proto/sign_service.proto",
+        "proto/utility_service.proto",
     ];
 
     for proto in &protos {

--- a/crates/proto/proto/utility_service.proto
+++ b/crates/proto/proto/utility_service.proto
@@ -1,0 +1,133 @@
+syntax = "proto3";
+
+// Package must match defradb.rs/crates/orbis/proto/orbis.proto
+// so gRPC routes correctly when DefraDB calls Orbis.
+package orbis.utility.v1;
+
+service UtilityService {
+  // Derive a child public key from a ring's master public key.
+  // Unauthenticated — anyone can derive a public key for any label.
+  rpc DerivePublicKey(DerivePublicKeyRequest) returns (DerivePublicKeyResponse);
+
+  // Request a threshold signature from the ring.
+  // Authenticated — caller must present a JWT authorizing the operation.
+  //
+  // The ring determines the signing scheme (BLS, FROST, etc.) based on
+  // how it was initialized during DKG. Clients may optionally specify
+  // `algorithm` as a guard: if the ring uses a different scheme, the
+  // request is rejected rather than silently producing the wrong type.
+  rpc Sign(SignRequest) returns (SignResponse);
+}
+
+// --- Algorithm Identification ---
+
+// Signing algorithms supported by the Orbis threshold signing protocol.
+//
+// Each algorithm corresponds to a specific ThresholdSigner implementation
+// in the crypto crate and determines the signature format, verification
+// method, and whether interactive nonce rounds (FROST) are required.
+enum SignAlgorithm {
+  // Unspecified — the ring's default algorithm is used.
+  SIGN_ALGORITHM_UNSPECIFIED = 0;
+
+  // BLS12-381 threshold signatures (non-interactive).
+  // Produces G2 point signatures verified via pairings.
+  // Protocol: single signing round, no nonce commitment.
+  // Use case: general-purpose signing, attestations.
+  SIGN_ALGORITHM_BLS = 1;
+
+  // FROST over Decaf377 (interactive Schnorr threshold signatures).
+  // Produces (R, z) Schnorr signatures over Penumbra's prime-order group.
+  // Protocol: two rounds (nonce commitment + signing).
+  // Use case: Penumbra-compatible signatures, EdDSA-like schemes.
+  SIGN_ALGORITHM_FROST_DECAF377 = 2;
+
+  // Reserved for future algorithms:
+  //   SIGN_ALGORITHM_FROST_ED25519 = 3;
+  //   SIGN_ALGORITHM_FROST_SECP256K1 = 4;
+  //   SIGN_ALGORITHM_ECDSA_SECP256K1 = 5;
+}
+
+// --- DerivePublicKey ---
+
+message DerivePublicKeyRequest {
+  // Ring whose master public key to derive from.
+  string ring_id = 1;
+
+  // Capability derivation label. The derived key is:
+  //   derived_pk = H(DERIVATION_DOMAIN || derivation) * ring_pk
+  // An empty value returns the ring's master public key directly.
+  bytes derivation = 2;
+}
+
+message DerivePublicKeyResponse {
+  // The derived public key (compressed curve point, algorithm-dependent encoding).
+  bytes public_key = 1;
+
+  // Which algorithm this public key belongs to.
+  // Lets clients know how to use/verify the key without out-of-band knowledge.
+  SignAlgorithm algorithm = 2;
+}
+
+// --- Sign ---
+
+message SignRequest {
+  // Ring to sign with.
+  string ring_id = 1;
+
+  // Message bytes to sign. Interpretation is algorithm-dependent:
+  //   BLS: hash-to-curve (H(msg) mapped to G2)
+  //   FROST: Fiat-Shamir challenge over raw bytes
+  bytes message = 2;
+
+  // Optional capability derivation. When set, the ring signs using
+  // the derived key (H(label) * share_i) rather than the master key.
+  // Must match the derivation used in DerivePublicKey to get the
+  // corresponding verification key.
+  bytes derivation = 3;
+
+  // Optional algorithm guard. If set and the ring uses a different
+  // algorithm, the request is rejected with INVALID_ARGUMENT.
+  // If UNSPECIFIED (0), the ring's native algorithm is used.
+  SignAlgorithm algorithm = 4;
+
+  // Extensibility: algorithm-specific or use-case-specific options.
+  // Reserved for future use. Examples of potential keys:
+  //   "hash_function": override the hash-to-curve method
+  //   "dst": domain separation tag for BLS
+  //   "aux_rand": additional randomness for FROST
+  map<string, bytes> options = 5;
+
+  // ACP authorization fields (optional — when non-empty, Orbis checks ACP on SourceHub).
+  // These must match the corresponding fields in the JWT claims.
+  string policy_id = 6;
+  string resource = 7;
+  string object_id = 8;
+  string permission = 9;
+
+  // AccessDecision ID (optional — when non-empty, Orbis verifies the decision
+  // exists on-chain via the ACP light client instead of performing a live ACP check).
+  // Mutually exclusive with policy_id: set one or the other, not both.
+  string decision_id = 10;
+}
+
+message SignResponse {
+  // The recovered threshold signature (algorithm-dependent encoding):
+  //   BLS: compressed G2 point (96 bytes)
+  //   FROST/Decaf377: (R || z) Schnorr signature
+  bytes signature = 1;
+
+  // Which algorithm produced this signature.
+  SignAlgorithm algorithm = 2;
+
+  // The public key that verifies this signature.
+  // Saves the client a DerivePublicKey round-trip when derivation was used.
+  bytes public_key = 3;
+
+  // Extensibility: additional response metadata.
+  // Reserved for future use. Examples of potential keys:
+  //   "participants": which node indices contributed shares
+  //   "session_id": signing session identifier for audit
+  //   "duration_ms": how long the threshold ceremony took
+  map<string, bytes> metadata = 4;
+}

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -17,3 +17,7 @@ pub mod store_secret_service {
 pub mod sign_service {
     tonic::include_proto!("sign_service");
 }
+
+pub mod utility_service {
+    tonic::include_proto!("orbis.utility.v1");
+}


### PR DESCRIPTION
## Summary

Consolidated branch with all orbis-rs changes needed for the [backbone](https://github.com/sourcenetwork/backbone) integration test harness. Rebased on current main, no orbis-e2e crate (tests live in backbone now).

### Commit 1: `--data-dir` flag for orbis-node
- Per-node state isolation (database + public_key.txt)
- Extract `resolve_base_dir()` helper to deduplicate fallback logic

### Commit 2: Parameterize cli-tool + new CLI functions
- All chain functions accept `ChainConfig` parameter (was hardcoded to local)
- New: `create_policy_on_chain`, `set_relationship_direct`, `delete_relationship_on_chain`, `signer_did_for_pk`, `get_latest_ring`
- New CLI subcommands: `derive-public-key`, `sign`, `get-latest-ring`
- Export `DerivePublicKeyResult`, `SignResult`, `SignAcpFields`

### Commit 3: DerivePublicKey + Sign utility services
- New `UtilityService` gRPC with DerivePublicKey and Sign RPCs
- `utility_service.proto` (package: `orbis.utility.v1`)
- `SignClaims` + `create_sign_jwt()` in authn crate
- Algorithm enum, ACP fields, options map in proto

### Commit 4: ACP enforcement in signing path
- `SignVerification` enum (Bulletin | Authenticated) for responder verification
- Independent ACP checks at both initiator and responder level
- Authenticated variant carries JWT for T-of-N independent verification
- CI: remove orbis-e2e jobs (tests moved to backbone)

## Test plan

- [x] `cargo check` — clean compile on main
- [x] Clippy warnings unchanged from main (pre-existing only)
- [ ] `cargo test --workspace` — unit tests pass
- [ ] Integration test via backbone: `cargo test -p orbis-harness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)