### PR TITLE
Remove TimestampRange

### DIFF
--- a/bin/cli-tool/src/commands.rs
+++ b/bin/cli-tool/src/commands.rs
@@ -358,8 +358,6 @@ pub async fn do_pre(
     namespace: String,
     derivation: Option<Vec<u8>>,
     salt: Option<String>,
-    valid_window_start: Option<u64>,
-    valid_window_end: Option<u64>,
     xnc_only: bool,
 ) -> Result<Vec<u8>> {
     println!("Starting PRE session:");
@@ -393,18 +391,12 @@ pub async fn do_pre(
         .await
         .map_err(|e| anyhow!("Failed to connect to {}: {}", endpoint, e))?;
 
-    let valid_window = match (valid_window_start, valid_window_end) {
-        (Some(start), Some(end)) => Some(proto::pre_service::TimestampRange { start, end }),
-        _ => None,
-    };
-
     let request = proto::pre_service::StartPreRequest {
         rdr_pk: reader_pk_bytes.clone(),
         object_id: object_id.clone(),
         namespace: namespace.clone(),
         derivation: derivation.clone(),
         salt: salt.clone(),
-        valid_window,
     };
 
     // JWT work use determinitic key_pair for now
@@ -1078,8 +1070,6 @@ pub async fn do_sign(
     namespace: String,
     derivation_id: String,
     reader_did_pk: Option<String>,
-    valid_window_start: Option<u64>,
-    valid_window_end: Option<u64>,
 ) -> Result<SignResult> {
     println!("Starting Sign session:");
     println!("  Endpoint: {}", endpoint);
@@ -1092,16 +1082,10 @@ pub async fn do_sign(
         .await
         .map_err(|e| anyhow!("Failed to connect to {}: {}", endpoint, e))?;
 
-    let valid_window = match (valid_window_start, valid_window_end) {
-        (Some(start), Some(end)) => Some(proto::sign_service::TimestampRange { start, end }),
-        _ => None,
-    };
-
     let request = proto::sign_service::StartSignRequest {
         message: message.clone(),
         namespace: namespace.clone(),
         derivation_id: derivation_id.clone(),
-        valid_window,
     };
 
     let reader_did_pk = reader_did_pk.unwrap_or("test_jwt".to_string());

--- a/bin/cli-tool/src/main.rs
+++ b/bin/cli-tool/src/main.rs
@@ -74,14 +74,6 @@ pub enum SubCommands {
         #[clap(long)]
         salt: Option<String>,
 
-        /// Start of the validity window (Unix timestamp, inclusive). Requires --valid-window-end.
-        #[clap(long)]
-        valid_window_start: Option<u64>,
-
-        /// End of the validity window (Unix timestamp, inclusive). Requires --valid-window-start.
-        #[clap(long)]
-        valid_window_end: Option<u64>,
-
         /// Print only the re-encrypted commitment (xnc_cmt) without decrypting.
         #[clap(long)]
         xnc_only: bool,
@@ -375,12 +367,6 @@ pub enum SubCommands {
         /// A private key to generate a reader DID for JWT
         #[clap(long)]
         reader_did_pk: Option<String>,
-        /// Start of the validity window (Unix timestamp, inclusive). Requires --valid-window-end.
-        #[clap(long)]
-        valid_window_start: Option<u64>,
-        /// End of the validity window (Unix timestamp, inclusive). Requires --valid-window-start.
-        #[clap(long)]
-        valid_window_end: Option<u64>,
     },
 }
 
@@ -406,20 +392,10 @@ async fn main() -> Result<()> {
             namespace,
             derivation,
             salt,
-            valid_window_start,
-            valid_window_end,
             xnc_only,
         } => {
             if !xnc_only && reader_sk.is_none() {
                 anyhow::bail!("--reader-sk is required unless --xnc-only is set");
-            }
-            match (valid_window_start, valid_window_end) {
-                (Some(_), None) | (None, Some(_)) => {
-                    anyhow::bail!(
-                        "--valid-window-start and --valid-window-end must both be provided"
-                    );
-                }
-                _ => {}
             }
             let derivation_bytes =
                 derivation.map(|d| hex::decode(&d).expect("Failed to decode derivation hex"));
@@ -433,8 +409,6 @@ async fn main() -> Result<()> {
                 namespace,
                 derivation_bytes,
                 salt,
-                valid_window_start,
-                valid_window_end,
                 xnc_only,
             )
             .await?;
@@ -651,17 +625,7 @@ async fn main() -> Result<()> {
             namespace,
             derivation_id,
             reader_did_pk,
-            valid_window_start,
-            valid_window_end,
         } => {
-            match (valid_window_start, valid_window_end) {
-                (Some(_), None) | (None, Some(_)) => {
-                    anyhow::bail!(
-                        "--valid-window-start and --valid-window-end must both be provided"
-                    );
-                }
-                _ => {}
-            }
             let message_bytes = hex::decode(&message)
                 .map_err(|e| anyhow::anyhow!("Failed to decode message hex: {}", e))?;
             do_sign(
@@ -670,8 +634,6 @@ async fn main() -> Result<()> {
                 namespace,
                 derivation_id,
                 reader_did_pk,
-                valid_window_start,
-                valid_window_end,
             )
             .await?;
         }

--- a/bin/orbis-node/src/pre/helpers.rs
+++ b/bin/orbis-node/src/pre/helpers.rs
@@ -59,13 +59,19 @@ pub async fn check_policy_access(
     issuer_id: &str,
     valid_window: Option<ValidWindow>,
 ) -> Result<()> {
+    // authz invariant (crates/authz/src/sourcehub/mod.rs:86-100): timestamp and
+    // valid_window must both be Some or both None. Mirrors what Sign already does
+    // at sign/helpers.rs:441 — only forward the bulletin timestamp when a window
+    // is being enforced. Until ACP populates the window server-side (issue #80),
+    // no window is set, so the timestamp is informational and must be elided here.
+    let timestamp = valid_window.as_ref().and(document_payload.timestamp);
     let permission = AccessCheckRequest::new(
         document_payload.policy_id.clone(),
         document_payload.resource.clone(),
         object_id.to_string(),
         document_payload.permission.clone(),
         document_payload.tier.clone(),
-        document_payload.timestamp,
+        timestamp,
         valid_window,
     )
     .to_bytes()

--- a/bin/orbis-node/src/pre/service.rs
+++ b/bin/orbis-node/src/pre/service.rs
@@ -82,13 +82,13 @@ where
             .map_err(PreError::Unauthorized)?;
 
         let req = request.into_inner();
-        let valid_window = req.valid_window.map(|w| ValidWindow {
-            start: w.start,
-            end: w.end,
-        });
 
         let (document_payload, ring_payload) =
             fetch_bulletin_payloads(&*self.state.bulletin, &req.namespace, &req.object_id).await?;
+
+        // ACP will populate the validity window server-side in a future change;
+        // until then no client-supplied window is honoured.
+        let valid_window: Option<ValidWindow> = None;
 
         check_policy_access(
             &*self.state.authz,

--- a/bin/orbis-node/src/pre/tests.rs
+++ b/bin/orbis-node/src/pre/tests.rs
@@ -958,7 +958,6 @@ async fn test_start_pre_fails_missing_auth_header() {
         object_id: "".to_string(),
         derivation: None,
         salt: None,
-        valid_window: None,
     };
 
     // Create request WITHOUT authentication header
@@ -1000,7 +999,6 @@ async fn test_start_pre_fails_malformed_jwt() {
         object_id: "".to_string(),
         derivation: None,
         salt: None,
-        valid_window: None,
     };
 
     // Create request with malformed JWT (not a valid JWT structure)
@@ -1059,7 +1057,6 @@ async fn test_start_pre_fails_wrong_signature() {
         object_id: "".to_string(),
         derivation: None,
         salt: None,
-        valid_window: None,
     };
 
     let tonic_request = create_authenticated_request(request, &tampered_token).unwrap();

--- a/bin/orbis-node/src/sign/service.rs
+++ b/bin/orbis-node/src/sign/service.rs
@@ -100,15 +100,14 @@ where
             Some(&req.message),
         )?;
 
-        let valid_window = req.valid_window.map(|w| ValidWindow {
-            start: w.start,
-            end: w.end,
-        });
-
         // Fetch ring and key derivation from bulletin (IO) ---
         let (key_derivation, ring_payload) =
             fetch_bulletin_payloads(&*self.state.bulletin, &req.namespace, &req.derivation_id)
                 .await?;
+
+        // ACP will populate the validity window server-side in a future change;
+        // until then no client-supplied window is honoured.
+        let valid_window: Option<ValidWindow> = None;
 
         // Authorize: check on-chain policy access (IO) ---
         check_policy_access(

--- a/bin/orbis-node/src/sign/tests.rs
+++ b/bin/orbis-node/src/sign/tests.rs
@@ -1747,7 +1747,6 @@ async fn test_sign_service_rejects_oversized_message() {
         namespace: "test-ns".to_string(),
         derivation_id: "test-derivation".to_string(),
         message: oversized_message,
-        valid_window: None,
     });
 
     let result = service.start_sign(request).await;

--- a/bin/orbis-node/src/tests/concurrent.rs
+++ b/bin/orbis-node/src/tests/concurrent.rs
@@ -561,8 +561,6 @@ async fn test_concurrent_pre_requests() {
             user_namespace.clone(),
             None,
             None,
-            None,
-            None,
             false,
         ),
         cli_tool::do_pre(
@@ -575,8 +573,6 @@ async fn test_concurrent_pre_requests() {
             user_namespace.clone(),
             None,
             None,
-            None,
-            None,
             false,
         ),
         cli_tool::do_pre(
@@ -587,8 +583,6 @@ async fn test_concurrent_pre_requests() {
             object_id.clone(),
             Some(did.clone()),
             user_namespace.clone(),
-            None,
-            None,
             None,
             None,
             false,

--- a/bin/orbis-node/src/tests/fault_injection.rs
+++ b/bin/orbis-node/src/tests/fault_injection.rs
@@ -368,8 +368,6 @@ async fn test_pre_one_node_down_succeeds() {
         user_namespace.clone(),
         None,
         None,
-        None,
-        None,
         false,
     )
     .await
@@ -492,8 +490,6 @@ async fn test_pre_below_threshold_nodes_down_fails_fast() {
             object_id.clone(),
             Some(did.clone()),
             user_namespace.clone(),
-            None,
-            None,
             None,
             None,
             false,

--- a/bin/orbis-node/src/tests/integration.rs
+++ b/bin/orbis-node/src/tests/integration.rs
@@ -215,8 +215,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
     let namespace = "docker_test_namespace".to_string();
     let tier = Some("tier".to_string());
     let timestamp = Some(100u64);
-    let valid_window_start = Some(50u64);
-    let valid_window_end = Some(150u64);
     let salt = Some("salt".to_string());
     let policy_id = cli_tool::add_policy_to_chain().await.expect("policy_id");
 
@@ -471,8 +469,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         None,
         None,
-        None,
-        None,
         false,
     )
     .await;
@@ -495,8 +491,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         Some(derivation.clone()),
         salt.clone(),
-        valid_window_start,
-        valid_window_end,
         false,
     )
     .await;
@@ -517,8 +511,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         Some(derivation.clone()),
         salt.clone(),
-        valid_window_start,
-        valid_window_end,
         false,
     )
     .await;
@@ -531,30 +523,11 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         err
     );
 
-    // testing timestamp out of bounds failure
-    let pre_result_derived_failed_timestamp = cli_tool::do_pre(
-        endpoint.clone(),
-        ring_pk_hex.clone(),
-        reader_pk_hex.clone(),
-        Some(reader_sk_hex.clone()),
-        object_id_derived.clone(),
-        Some(did_pk_string.clone()),
-        namespace.clone(),
-        Some(derivation),
-        salt.clone(),
-        valid_window_start,
-        valid_window_start,
-        false,
-    )
-    .await;
-
-    let err = pre_result_derived_failed_timestamp.unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("Access denied: policy check failed"),
-        "Expected timestamp out-of-bounds failure, got: {}",
-        err
-    );
+    // NOTE: The "client-supplied timestamp out of bounds" test that previously
+    // lived here has been removed alongside `StartPreRequest.valid_window` —
+    // see issue #80. The same coverage is provided server-side by
+    // `crates/authz/src/sourcehub/tests.rs::test_valid_window_out_of_range`
+    // against the `ValidWindow` path that ACP will populate.
 
     // Test idempotency: store the same prepared secret again
     // This should succeed and return the same object_id (no duplicate post)
@@ -673,8 +646,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         derivation_id.clone(),
         Some(sign_did_pk.clone()),
-        None,
-        None,
     )
     .await;
 
@@ -713,8 +684,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         derivation_id.clone(),
         Some("unauthorized_did_key".to_string()),
-        None,
-        None,
     )
     .await;
 
@@ -894,8 +863,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         derivation_id.clone(),
         Some(sign_did_pk.clone()),
-        None,
-        None,
     )
     .await;
 
@@ -924,8 +891,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         namespace.clone(),
         derivation_id.clone(),
         Some(sign_did_pk.clone()),
-        None,
-        None,
     )
     .await;
 
@@ -1007,8 +972,6 @@ async fn test_cli_calls_dkg_and_pre_endpoint() {
         object_id_post_refresh.clone(),
         Some(did_pk_string.clone()),
         namespace.clone(),
-        None,
-        None,
         None,
         None,
         false,
@@ -1149,8 +1112,6 @@ async fn do_sign_expect_success(
     namespace: String,
     derivation_id: String,
     reader_did_pk: Option<String>,
-    valid_window_start: Option<u64>,
-    valid_window_end: Option<u64>,
 ) -> cli_tool::SignResult {
     let deadline = Instant::now() + Duration::from_secs(90);
     let mut attempt = 1usize;
@@ -1162,8 +1123,6 @@ async fn do_sign_expect_success(
             namespace.clone(),
             derivation_id.clone(),
             reader_did_pk.clone(),
-            valid_window_start,
-            valid_window_end,
         )
         .await
         {
@@ -1198,8 +1157,6 @@ async fn do_pre_expect_success(
     namespace: String,
     derivation: Option<Vec<u8>>,
     salt: Option<String>,
-    valid_window_start: Option<u64>,
-    valid_window_end: Option<u64>,
     xnc_only: bool,
 ) -> Vec<u8> {
     let deadline = Instant::now() + Duration::from_secs(90);
@@ -1216,8 +1173,6 @@ async fn do_pre_expect_success(
             namespace.clone(),
             derivation.clone(),
             salt.clone(),
-            valid_window_start,
-            valid_window_end,
             xnc_only,
         )
         .await

--- a/crates/proto/proto/pre_service.proto
+++ b/crates/proto/proto/pre_service.proto
@@ -6,11 +6,6 @@ service PreService {
   rpc StartPre(StartPreRequest) returns (StartPreResponse);
 }
 
-message TimestampRange {
-  uint64 start = 1;
-  uint64 end = 2;
-}
-
 message StartPreRequest {
   // reader public key
   bytes rdr_pk = 1;
@@ -22,9 +17,6 @@ message StartPreRequest {
   optional bytes derivation = 4;
   // Optional salt for proof
   optional string salt = 5;
-  // Optional timestamp range for validity window
-  // TODO: Insecure test code meant to be moved to acp eventually (not in authn either)
-  optional TimestampRange valid_window = 6;
 }
 
 message StartPreResponse {

--- a/crates/proto/proto/sign_service.proto
+++ b/crates/proto/proto/sign_service.proto
@@ -6,11 +6,6 @@ service SignService {
   rpc StartSign(StartSignRequest) returns (StartSignResponse);
 }
 
-message TimestampRange {
-  uint64 start = 1;
-  uint64 end = 2;
-}
-
 message StartSignRequest {
   // Raw bytes to sign
   bytes message = 1;
@@ -18,8 +13,6 @@ message StartSignRequest {
   string namespace = 2;
   // Object ID of the KeyDerivation entry on the bulletin
   string derivation_id = 3;
-  // Optional timestamp range for validity window
-  optional TimestampRange valid_window = 4;
 }
 
 message StartSignResponse {


### PR DESCRIPTION
  ## Summary

  Removes the client-supplied `TimestampRange` field from both `StartPreRequest` and `StartSignRequest`. The field was demo code — excluded from AuthN claims because trusting a client-supplied time window is unsafe. ACP will populate the validity window server-side in a future change.
  
  ## Changes

  - `TimestampRange` message and `valid_window` field from `pre_service.proto` and `sign_service.proto`.
  - Proto → `ValidWindow` conversion in `pre/service.rs` and `sign/service.rs` (now always pass `None`).
  - `--valid-window-start` / `--valid-window-end` flags from the `pre` and `sign` CLI subcommands.
  - The "client-supplied out-of-range" PRE integration test (equivalent server-side coverage already exists in `crates/authz/src/sourcehub/tests.rs`).
  