### PR TITLE
ci: Publish Docker image for develop changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,8 @@ on:
         required: false
         type: string
   push:
+    branches:
+      - develop
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 


### PR DESCRIPTION
Currently, the workflow files only build and publish docker images on tagged releases. This trigger the build on every push to develop. 

(Last release is 2 months old)