### PR TITLE
feat: Set Password File from Env

### DIFF
--- a/bin/orbis-node/src/constants.rs
+++ b/bin/orbis-node/src/constants.rs
@@ -313,6 +313,9 @@ pub const PASSWORD_FILE_NAME: &str = ".orbis_password";
 /// in a shell script or Dockerfile ENV instruction.
 pub const PASSWORD_ENV_VAR: &str = "ORBIS_PASSWORD";
 
+/// Environment variable naming the path of the password file
+pub const PASSWORD_FILE_ENV_VAR: &str = "ORBIS_PASSWORD_FILE";
+
 // ============================================================================
 // Secret Key (Peer Identity) Configuration Constants
 // ============================================================================

--- a/bin/orbis-node/src/runtime.rs
+++ b/bin/orbis-node/src/runtime.rs
@@ -18,6 +18,7 @@ use local_storage::{r#trait::LocalStorage, LocalStorageImpl};
 use network::{Network, NetworkImpl, Router};
 use std::{
     net::SocketAddr,
+    path::PathBuf,
     sync::{
         atomic::{AtomicI32, Ordering},
         Arc,
@@ -114,8 +115,15 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("Bulletin implementation: {}", BulletinImpl::name());
         tracing::info!("Network implementation: {}", NetworkImpl::name());
 
-        // Get password for encrypting ring key shares
-        let password = get_password(None).map_err(|e| format!("Failed to get password: {}", e))?;
+        // Get password for encrypting ring key shares. 
+        // Loads from environment, if available,
+        // otherwise uses default orbis location
+        let password_file = std::env::var(constants::PASSWORD_FILE_ENV_VAR)
+        .ok()
+        .filter(|file| !file.is_empty())
+        .map(PathBuf::from);
+        let password =
+            get_password(password_file).map_err(|e| format!("Failed to get password: {}", e))?;
         let local_storage = LocalStorageImpl::new(password, db_path(&runtime_base_path, "orbis"))
             .map_err(|e| format!("Failed to create local storage: {}", e))?;
         // Get node secret hex for netwokring

--- a/bin/orbis-node/src/runtime.rs
+++ b/bin/orbis-node/src/runtime.rs
@@ -115,12 +115,14 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("Bulletin implementation: {}", BulletinImpl::name());
         tracing::info!("Network implementation: {}", NetworkImpl::name());
 
-        // Get password for encrypting ring key shares. 
+        // Get password for encrypting ring key shares.
         // Loads from environment, if available,
         // otherwise uses default orbis location
         let password_file = std::env::var(constants::PASSWORD_FILE_ENV_VAR)
-        .map_err(|e| format!("Failed to load env var: {}", e))?;
-        let password_file = Some(password_file).filter(|file| !file.is_empty()).map(PathBuf::from);
+            .map_err(|e| format!("Failed to load env var: {}", e))?;
+        let password_file = Some(password_file)
+            .filter(|file| !file.is_empty())
+            .map(PathBuf::from);
         let password =
             get_password(password_file).map_err(|e| format!("Failed to get password: {}", e))?;
         let local_storage = LocalStorageImpl::new(password, db_path(&runtime_base_path, "orbis"))

--- a/bin/orbis-node/src/runtime.rs
+++ b/bin/orbis-node/src/runtime.rs
@@ -119,9 +119,8 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         // Loads from environment, if available,
         // otherwise uses default orbis location
         let password_file = std::env::var(constants::PASSWORD_FILE_ENV_VAR)
-        .ok()
-        .filter(|file| !file.is_empty())
-        .map(PathBuf::from);
+        .map_err(|e| format!("Failed to load env var: {}", e))?;
+        let password_file = Some(password_file).filter(|file| !file.is_empty()).map(PathBuf::from);
         let password =
             get_password(password_file).map_err(|e| format!("Failed to get password: {}", e))?;
         let local_storage = LocalStorageImpl::new(password, db_path(&runtime_base_path, "orbis"))

--- a/bin/orbis-node/src/runtime.rs
+++ b/bin/orbis-node/src/runtime.rs
@@ -119,8 +119,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         // Loads from environment, if available,
         // otherwise uses default orbis location
         let password_file = std::env::var(constants::PASSWORD_FILE_ENV_VAR)
-            .map_err(|e| format!("Failed to load env var: {}", e))?;
-        let password_file = Some(password_file)
+            .ok()
             .filter(|file| !file.is_empty())
             .map(PathBuf::from);
         let password =


### PR DESCRIPTION
Add env var to specify the password file, not just the password itself.

This decouples the Orbis data / working directory from the password Secret, which means the secret can be mounted in a special Read-Only partition through bind mounts or docker/kubernetes volumes