### PR TITLE
fix: advertise the signing-derived key, carry the derivation, and match Vera's wire types

### DIFF
--- a/bin/cli-tool/src/commands.rs
+++ b/bin/cli-tool/src/commands.rs
@@ -1276,8 +1276,8 @@ pub async fn do_utility_sign(
 
     // Create JWT for authentication
     let signer_did_pk = signer_did_pk.unwrap_or("test_jwt".to_string());
-    let seed_bytes = hex::decode(&signer_did_pk)
-        .unwrap_or_else(|_| signer_did_pk.as_bytes().to_vec());
+    let seed_bytes =
+        hex::decode(&signer_did_pk).unwrap_or_else(|_| signer_did_pk.as_bytes().to_vec());
     let key_pair = generate::<DidEd25519KeyPair>(Some(&seed_bytes));
     let jwt_signer = JwtSigner::from_key_pair(key_pair);
     let token = jwt_signer

--- a/bin/cli-tool/src/main.rs
+++ b/bin/cli-tool/src/main.rs
@@ -8,8 +8,8 @@ pub use commands::{
     do_utility_sign, fund, get_account_sequence, get_latest_ring, list_bulletin_posts,
     post_key_derivation, prepare_secret, query_node_info, read_bulletin_post,
     register_bulletin_namespace, register_object_to_chain, set_relationship_on_chain,
-    signer_did_for_pk, store_prepared_secret, DerivePublicKeyResult, PreparedSecret,
-    SignAcpFields, SignResult, UtilitySignResult,
+    signer_did_for_pk, store_prepared_secret, DerivePublicKeyResult, PreparedSecret, SignAcpFields,
+    SignResult, UtilitySignResult,
 };
 use common::blockchain::ChainConfig;
 use hex;
@@ -750,7 +750,11 @@ async fn main() -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("Failed to decode message hex: {}", e))?;
             let derivation_bytes =
                 derivation.map(|d| hex::decode(&d).expect("Failed to decode derivation hex"));
-            let acp = if policy_id.is_some() || resource.is_some() || object_id.is_some() || permission.is_some() {
+            let acp = if policy_id.is_some()
+                || resource.is_some()
+                || object_id.is_some()
+                || permission.is_some()
+            {
                 Some(SignAcpFields {
                     policy_id: policy_id.unwrap_or_default(),
                     resource: resource.unwrap_or_default(),
@@ -788,7 +792,10 @@ async fn main() -> Result<()> {
         SubCommands::SignerDid { signer_did_pk } => {
             let did = signer_did_for_pk(&signer_did_pk);
             if matches!(cli.output, OutputFormat::Json) {
-                println!("{}", serde_json::to_string_pretty(&serde_json::json!({"did": did}))?);
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({"did": did}))?
+                );
             } else {
                 println!("{}", did);
             }

--- a/bin/orbis-node/src/helpers/launch.rs
+++ b/bin/orbis-node/src/helpers/launch.rs
@@ -34,6 +34,11 @@ pub struct Args {
     /// Chain REST URL (Cosmos REST API endpoint)
     #[arg(long, default_value = "http://localhost:1317")]
     pub chain_rest: Option<String>,
+    /// Chain ID of the Vera chain this node signs transactions for. It is part
+    /// of every signed transaction, so a value that does not match the chain
+    /// makes signature verification fail on every send.
+    #[arg(long)]
+    pub chain_id: Option<String>,
     /// denomination of chain gas tokens
     #[arg(long)]
     pub denom: Option<String>,
@@ -339,7 +344,11 @@ pub fn db_path(name: &str, data_dir: Option<&str>) -> String {
     let base = resolve_base_dir(data_dir);
     // With explicit --data-dir, put the db directly in it.
     // With auto-resolved root, use a "dbs" subdirectory to keep things tidy.
-    let db_dir = if data_dir.is_some() { base } else { base.join("dbs") };
+    let db_dir = if data_dir.is_some() {
+        base
+    } else {
+        base.join("dbs")
+    };
     std::fs::create_dir_all(&db_dir).ok();
     format!("{}/{}.redb", db_dir.display(), name)
 }

--- a/bin/orbis-node/src/main.rs
+++ b/bin/orbis-node/src/main.rs
@@ -16,12 +16,11 @@ mod tests;
 
 use crate::dkg::service::DkgServiceImpl;
 use crate::helpers::create_routers::create_router_with_all_handlers;
-use crate::helpers::launch::{
-    db_path, derive_secret_key_bytes, get_network_key_secret,
-    get_password, Args,
-};
 #[cfg(feature = "bulletin-sourcehub")]
 use crate::helpers::launch::create_and_store_node_key;
+use crate::helpers::launch::{
+    db_path, derive_secret_key_bytes, get_network_key_secret, get_password, Args,
+};
 #[cfg(feature = "bulletin-hubrs")]
 use crate::helpers::launch::{get_or_create_signing_key_hex, resolve_base_dir};
 use crate::info::InfoServiceImpl;
@@ -158,8 +157,7 @@ pub async fn run_server(node: InitializedNode) -> Result<(), Box<dyn std::error:
     let store_secret_service =
         StoreSecretServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
     let sign_service = SignServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
-    let utility_service =
-        UtilityServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
+    let utility_service = UtilityServiceImpl::<DkgImpl, SignImpl>::new((*node.app_state).clone());
 
     // Start gRPC server with DKG, PRE, Info, StoreSecret, Sign, and Utility services
     let grpc_server = tonic::transport::Server::builder()
@@ -268,6 +266,7 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         .grpc_url(args.authz_grpc.clone())
         .rpc_url(args.chain_rpc.clone())
         .rest_url(args.chain_rest.clone())
+        .chain_id(args.chain_id.clone())
         .denom(args.denom.clone());
 
     let authz: Arc<dyn Authz> = Arc::new(
@@ -283,9 +282,14 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             .grpc_url(args.bulletin_grpc.clone())
             .rpc_url(args.chain_rpc.clone())
             .rest_url(args.chain_rest.clone())
+            .chain_id(args.chain_id.clone())
             .denom(args.denom.clone());
-        let signer = create_and_store_node_key(local_storage.clone(), chain_config_builder.clone().build(), args.data_dir.as_deref())
-            .map_err(|e| format!("Failed to create or store node key: {}", e))?;
+        let signer = create_and_store_node_key(
+            local_storage.clone(),
+            chain_config_builder.clone().build(),
+            args.data_dir.as_deref(),
+        )
+        .map_err(|e| format!("Failed to create or store node key: {}", e))?;
 
         // For integration tests, this funds the account, this is handled differently live
         #[cfg(feature = "integration-test")]
@@ -308,8 +312,9 @@ pub async fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
             .hub_rpc
             .clone()
             .ok_or("--hub-rpc is required when using the hubrs bulletin backend")?;
-        let hex_key = get_or_create_signing_key_hex(local_storage.clone(), args.data_dir.as_deref())
-            .map_err(|e| format!("Failed to create or retrieve signing key: {}", e))?;
+        let hex_key =
+            get_or_create_signing_key_hex(local_storage.clone(), args.data_dir.as_deref())
+                .map_err(|e| format!("Failed to create or retrieve signing key: {}", e))?;
         let config = bulletin::hubrs::HubRsConfig {
             rpc_url: hub_rpc,
             chain_id: args.hub_chain_id,

--- a/bin/orbis-node/src/sign/coordinator.rs
+++ b/bin/orbis-node/src/sign/coordinator.rs
@@ -178,7 +178,8 @@ where
                 )
                 .await?;
             }
-            SignContext::Authenticated { ref jwt, .. } | SignContext::AccessDecision { ref jwt, .. } => {
+            SignContext::Authenticated { ref jwt, .. }
+            | SignContext::AccessDecision { ref jwt, .. } => {
                 // Validate JWT — responder independently verifies the token is valid
                 let current_time = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -334,6 +335,7 @@ where
                 ref resource,
                 ref object_id,
                 ref permission,
+                ref derivation,
             } => {
                 // Validate JWT independently
                 let current_time = SystemTime::now()
@@ -389,18 +391,17 @@ where
                             ring_id, e
                         ))
                     })?;
-                let ring_payload =
-                    serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                let ring_payload = serde_json::from_slice::<RingPayload>(&ring_info.payload)
+                    .map_err(|e| {
                         SignError::Deserialization(format!("Failed to parse ring payload: {}", e))
                     })?;
 
-                let pub_poly_bytes =
-                    hex::decode(&ring_payload.public_polynomial).map_err(|e| {
-                        SignError::Deserialization(format!(
-                            "Failed to decode public polynomial hex: {}",
-                            e
-                        ))
-                    })?;
+                let pub_poly_bytes = hex::decode(&ring_payload.public_polynomial).map_err(|e| {
+                    SignError::Deserialization(format!(
+                        "Failed to decode public polynomial hex: {}",
+                        e
+                    ))
+                })?;
                 let pub_poly = <D::PubPoly>::from_bytes(&pub_poly_bytes).map_err(|e| {
                     SignError::Deserialization(format!(
                         "Failed to deserialize public polynomial: {}",
@@ -408,12 +409,13 @@ where
                     ))
                 })?;
 
-                (ring_payload.ring_pk, pub_poly, None, None)
+                (ring_payload.ring_pk, pub_poly, derivation.clone(), None)
             }
             SignContext::AccessDecision {
                 ref jwt,
                 ref ring_id,
                 ref decision_id,
+                ref derivation,
             } => {
                 // Validate JWT independently
                 let current_time = SystemTime::now()
@@ -434,9 +436,7 @@ where
                 let result = light_client
                     .check_access_decision(decision_id)
                     .await
-                    .map_err(|e| {
-                        SignError::AuthZ(format!("ACP light client error: {}", e))
-                    })?;
+                    .map_err(|e| SignError::AuthZ(format!("ACP light client error: {}", e)))?;
                 if !result.allowed {
                     return Err(SignError::AuthZ(format!(
                         "AccessDecision '{}' not authorized on-chain",
@@ -456,18 +456,17 @@ where
                             ring_id, e
                         ))
                     })?;
-                let ring_payload =
-                    serde_json::from_slice::<RingPayload>(&ring_info.payload).map_err(|e| {
+                let ring_payload = serde_json::from_slice::<RingPayload>(&ring_info.payload)
+                    .map_err(|e| {
                         SignError::Deserialization(format!("Failed to parse ring payload: {}", e))
                     })?;
 
-                let pub_poly_bytes =
-                    hex::decode(&ring_payload.public_polynomial).map_err(|e| {
-                        SignError::Deserialization(format!(
-                            "Failed to decode public polynomial hex: {}",
-                            e
-                        ))
-                    })?;
+                let pub_poly_bytes = hex::decode(&ring_payload.public_polynomial).map_err(|e| {
+                    SignError::Deserialization(format!(
+                        "Failed to decode public polynomial hex: {}",
+                        e
+                    ))
+                })?;
                 let pub_poly = <D::PubPoly>::from_bytes(&pub_poly_bytes).map_err(|e| {
                     SignError::Deserialization(format!(
                         "Failed to deserialize public polynomial: {}",
@@ -475,7 +474,7 @@ where
                     ))
                 })?;
 
-                (ring_payload.ring_pk, pub_poly, None, None)
+                (ring_payload.ring_pk, pub_poly, derivation.clone(), None)
             }
         };
 
@@ -783,7 +782,8 @@ where
                 ));
                 (derivation, meta)
             }
-            SignContext::Authenticated { .. } | SignContext::AccessDecision { .. } => (None, None),
+            SignContext::Authenticated { derivation, .. }
+            | SignContext::AccessDecision { derivation, .. } => (derivation.clone(), None),
         };
 
         // =====================================================================

--- a/bin/orbis-node/src/sign/messages.rs
+++ b/bin/orbis-node/src/sign/messages.rs
@@ -52,6 +52,15 @@ pub enum SignContext {
         object_id: String,
         /// ACP permission/relationship to check
         permission: String,
+        /// Derivation path requested by the client, or `None` to sign from the
+        /// ring's root key.
+        ///
+        /// A client that advertises a derived public key (`DerivePublicKey`)
+        /// must get a signature under that same derived key, or every verifier
+        /// rejects it. Dropping this made the ring sign from the root key while
+        /// the client published the derived one, which surfaced downstream as
+        /// `BLST_VERIFY_FAIL` on merge rather than as an error here.
+        derivation: Option<Vec<u8>>,
     },
     /// JWT-verified signing with on-chain AccessDecision verification via ACP light client.
     /// Each responder independently validates the JWT and checks the decision via AcpLightClient.
@@ -62,6 +71,8 @@ pub enum SignContext {
         ring_id: String,
         /// The on-chain access decision ID to verify
         decision_id: String,
+        /// Derivation path requested by the client, or `None` for the root key.
+        derivation: Option<Vec<u8>>,
     },
 }
 

--- a/bin/orbis-node/src/tests/concurrent.rs
+++ b/bin/orbis-node/src/tests/concurrent.rs
@@ -178,6 +178,7 @@ async fn setup_live_three_node_network(db_prefix: &str, base_port: u16) -> LiveT
                 bulletin_grpc: None,
                 chain_rest: None,
                 chain_rpc: None,
+                chain_id: None,
                 denom: None,
                 data_dir: None,
                 metrics_addr: None,

--- a/bin/orbis-node/src/tests/concurrent.rs
+++ b/bin/orbis-node/src/tests/concurrent.rs
@@ -124,9 +124,12 @@ async fn setup_live_three_node_network(db_prefix: &str, base_port: u16) -> LiveT
         let local_storage = LocalStorageImpl::new(None, db_path.clone()).expect("local storage");
 
         // Create signing key (stored in local_storage) and fund it via the faucet
-        let signer =
-            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build(), None)
-                .expect("create node signing key");
+        let signer = create_and_store_node_key(
+            local_storage.clone(),
+            ChainConfigBuilder::default().build(),
+            None,
+        )
+        .expect("create node signing key");
         let public_address = signer.address();
 
         cli_tool::fund(

--- a/bin/orbis-node/src/tests/fault_injection.rs
+++ b/bin/orbis-node/src/tests/fault_injection.rs
@@ -185,6 +185,7 @@ async fn setup_fault_three_node_network(
                 bulletin_grpc: None,
                 chain_rest: None,
                 chain_rpc: None,
+                chain_id: None,
                 denom: None,
                 data_dir: None,
                 metrics_addr: None,

--- a/bin/orbis-node/src/tests/fault_injection.rs
+++ b/bin/orbis-node/src/tests/fault_injection.rs
@@ -128,9 +128,12 @@ async fn setup_fault_three_node_network(
 
         let local_storage = LocalStorageImpl::new(None, db_path.clone()).expect("local storage");
 
-        let signer =
-            create_and_store_node_key(local_storage.clone(), ChainConfigBuilder::default().build(), None)
-                .expect("create node signing key");
+        let signer = create_and_store_node_key(
+            local_storage.clone(),
+            ChainConfigBuilder::default().build(),
+            None,
+        )
+        .expect("create node signing key");
         let public_address = signer.address();
 
         cli_tool::fund(

--- a/bin/orbis-node/src/tests/node.rs
+++ b/bin/orbis-node/src/tests/node.rs
@@ -47,6 +47,7 @@ async fn make_test_node_config(
             bulletin_grpc: None,
             chain_rest: None,
             chain_rpc: None,
+            chain_id: None,
             denom: None,
             data_dir: None,
             metrics_addr: None,

--- a/bin/orbis-node/src/tests/node.rs
+++ b/bin/orbis-node/src/tests/node.rs
@@ -348,8 +348,8 @@ fn test_create_and_store_node_key() {
     let signer1 = result.unwrap();
     let address1 = signer1.address();
     assert!(
-        address1.starts_with("source1"),
-        "Address should be bech32 with source1 prefix, got: {}",
+        address1.starts_with("vera1"),
+        "Address should be bech32 with vera1 prefix, got: {}",
         address1
     );
 

--- a/bin/orbis-node/src/utility/service.rs
+++ b/bin/orbis-node/src/utility/service.rs
@@ -7,8 +7,7 @@ use crate::utility::error::UtilityError;
 use authn::{extract_bearer_token, resolve_jwt_did, BearerToken, SignClaims};
 use authz::sourcehub::AccessCheckRequest;
 use bulletin::r#trait::RingPayload;
-use crypto::r#trait::{CryptoDeserialize, CryptoSerialize, Dkg, ThresholdDealer, ThresholdSigner};
-use crypto::PreImpl as ThresholdDealerNode;
+use crypto::r#trait::{CryptoDeserialize, CryptoSerialize, Dkg, ThresholdSigner};
 use proto::utility_service::{
     utility_service_server::UtilityService, DerivePublicKeyRequest, DerivePublicKeyResponse,
     SignAlgorithm, SignRequest, SignResponse as ProtoSignResponse,
@@ -93,10 +92,7 @@ where
             .read(BULLETIN_RING_NAMESPACE.to_string(), req.ring_id.clone())
             .await
             .map_err(|e| {
-                UtilityError::RingNotFound(format!(
-                    "Failed to read ring '{}': {}",
-                    req.ring_id, e
-                ))
+                UtilityError::RingNotFound(format!("Failed to read ring '{}': {}", req.ring_id, e))
             })?;
 
         let ring_payload =
@@ -105,18 +101,25 @@ where
             })?;
 
         // 2. Parse ring_pk from hex -> G1Affine
-        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk).map_err(|e| {
-            UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e))
-        })?;
+        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk)
+            .map_err(|e| UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e)))?;
         let ring_pk = <D::PublicKey>::from_bytes(&ring_pk_bytes).map_err(|e| {
             UtilityError::Deserialization(format!("Invalid ring_pk curve point: {}", e))
         })?;
 
-        // 3. Derive public key
-        let derived_pk =
-            ThresholdDealerNode::derive_public_key(&ring_pk, &req.derivation).map_err(|e| {
-                UtilityError::Crypto(format!("Failed to derive public key: {}", e))
-            })?;
+        // 3. Derive the public key threshold signatures under this derivation
+        //    will actually carry.
+        //
+        //    There are two derivation scalars in the crypto crate: the PRE
+        //    capability scalar (`Dkg::derive_public_key`, two arguments) and
+        //    the signing scalar (`ThresholdSigner::derive_public_key`, which
+        //    also takes metadata). This RPC exists to tell a client which key
+        //    to publish for signature verification, so it must use the signing
+        //    one. Using the capability scalar here returned a key no signature
+        //    ever verifies under, and the mismatch surfaced only on a peer as
+        //    `BLST_VERIFY_FAIL` when it merged an otherwise valid block.
+        let derived_pk = <S as ThresholdSigner>::derive_public_key(&ring_pk, &req.derivation, None)
+            .map_err(|e| UtilityError::Crypto(format!("Failed to derive public key: {}", e)))?;
 
         // 4. Serialize derived key
         let derived_pk_bytes = CryptoSerialize::to_bytes(&derived_pk).map_err(|e| {
@@ -143,16 +146,16 @@ where
         let token_str = extract_bearer_token(&request)
             .map_err(|e| UtilityError::Unauthorized(e.to_string()))?;
         let jwt_string = token_str.to_string();
-        let token: BearerToken<SignClaims> = resolve_jwt_did(token_str, current_time, MAX_TOKEN_LIFETIME_SECS)
-            .map_err(|e| {
-                UtilityError::Unauthorized(format!("JWT validation failed: {}", e))
-            })?;
+        let token: BearerToken<SignClaims> =
+            resolve_jwt_did(token_str, current_time, MAX_TOKEN_LIFETIME_SECS)
+                .map_err(|e| UtilityError::Unauthorized(format!("JWT validation failed: {}", e)))?;
 
         let req = request.into_inner();
 
         // 2. Algorithm guard
         let ring_algorithm = signer_algorithm::<S>();
-        let requested = SignAlgorithm::try_from(req.algorithm).unwrap_or(SignAlgorithm::Unspecified);
+        let requested =
+            SignAlgorithm::try_from(req.algorithm).unwrap_or(SignAlgorithm::Unspecified);
         if requested != SignAlgorithm::Unspecified && requested != ring_algorithm {
             return Err(UtilityError::UnsupportedAlgorithm(format!(
                 "requested algorithm {:?} but ring uses {:?}",
@@ -171,10 +174,10 @@ where
             .into());
         }
         if token.claims.message != req.message {
-            return Err(
-                UtilityError::Unauthorized("Token message does not match request".to_string())
-                    .into(),
-            );
+            return Err(UtilityError::Unauthorized(
+                "Token message does not match request".to_string(),
+            )
+            .into());
         }
         let req_derivation = if req.derivation.is_empty() {
             None
@@ -207,9 +210,7 @@ where
             let result = light_client
                 .check_access_decision(&req.decision_id)
                 .await
-                .map_err(|e| {
-                    UtilityError::Signing(format!("ACP light client error: {}", e))
-                })?;
+                .map_err(|e| UtilityError::Signing(format!("ACP light client error: {}", e)))?;
             if !result.allowed {
                 return Err(UtilityError::Unauthorized(format!(
                     "AccessDecision '{}' not authorized on-chain",
@@ -272,10 +273,7 @@ where
             .read(BULLETIN_RING_NAMESPACE.to_string(), req.ring_id.clone())
             .await
             .map_err(|e| {
-                UtilityError::RingNotFound(format!(
-                    "Failed to read ring '{}': {}",
-                    req.ring_id, e
-                ))
+                UtilityError::RingNotFound(format!("Failed to read ring '{}': {}", req.ring_id, e))
             })?;
 
         let ring_payload =
@@ -284,19 +282,24 @@ where
             })?;
 
         // 5. Compute the public key that will verify this signature
-        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk).map_err(|e| {
-            UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e))
-        })?;
+        let ring_pk_bytes = hex::decode(&ring_payload.ring_pk)
+            .map_err(|e| UtilityError::Deserialization(format!("Invalid ring_pk hex: {}", e)))?;
         let verification_pk = if req.derivation.is_empty() {
             ring_pk_bytes.clone()
         } else {
             let ring_pk = <D::PublicKey>::from_bytes(&ring_pk_bytes).map_err(|e| {
                 UtilityError::Deserialization(format!("Invalid ring_pk curve point: {}", e))
             })?;
-            let derived = ThresholdDealerNode::derive_public_key(&ring_pk, &req.derivation)
-                .map_err(|e| UtilityError::Crypto(format!("Failed to derive public key: {}", e)))?;
-            CryptoSerialize::to_bytes(&derived)
-                .map_err(|e| UtilityError::Crypto(format!("Failed to serialize public key: {}", e)))?
+            // Same signing scalar the threshold signature is produced under,
+            // not the PRE capability scalar; see `derive_public_key` above.
+            let derived =
+                <S as ThresholdSigner>::derive_public_key(&ring_pk, &req.derivation, None)
+                    .map_err(|e| {
+                        UtilityError::Crypto(format!("Failed to derive public key: {}", e))
+                    })?;
+            CryptoSerialize::to_bytes(&derived).map_err(|e| {
+                UtilityError::Crypto(format!("Failed to serialize public key: {}", e))
+            })?
         };
 
         // Validate peers
@@ -327,6 +330,7 @@ where
                 jwt: jwt_string,
                 ring_id: req.ring_id.clone(),
                 decision_id: req.decision_id.clone(),
+                derivation: req_derivation.clone(),
             }
         } else {
             SignContext::Authenticated {
@@ -336,6 +340,7 @@ where
                 resource: req.resource.clone(),
                 object_id: req.object_id.clone(),
                 permission: req.permission.clone(),
+                derivation: req_derivation.clone(),
             }
         };
 
@@ -346,14 +351,11 @@ where
             .await
             .map_err(|e| UtilityError::Signing(format!("Signing failed: {}", e)))?;
 
-        let sign_response: SignResponse =
-            serde_json::from_slice(&response_bytes).map_err(|e| {
-                UtilityError::Signing(format!("Failed to parse sign response: {}", e))
-            })?;
+        let sign_response: SignResponse = serde_json::from_slice(&response_bytes)
+            .map_err(|e| UtilityError::Signing(format!("Failed to parse sign response: {}", e)))?;
 
-        let signature_bytes = hex::decode(&sign_response.signature).map_err(|e| {
-            UtilityError::Signing(format!("Failed to decode signature hex: {}", e))
-        })?;
+        let signature_bytes = hex::decode(&sign_response.signature)
+            .map_err(|e| UtilityError::Signing(format!("Failed to decode signature hex: {}", e)))?;
 
         Ok(Response::new(ProtoSignResponse {
             signature: signature_bytes,

--- a/crates/bulletin/src/hubrs/client.rs
+++ b/crates/bulletin/src/hubrs/client.rs
@@ -42,8 +42,9 @@ impl EvmClient {
             .ok_or_else(|| BulletinError::ChainError("eth_call returned non-string".into()))?;
 
         let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-        hex::decode(hex_str)
-            .map_err(|e| BulletinError::ChainError(format!("Failed to decode eth_call result: {}", e)))
+        hex::decode(hex_str).map_err(|e| {
+            BulletinError::ChainError(format!("Failed to decode eth_call result: {}", e))
+        })
     }
 
     /// Get the transaction count (nonce) for an address
@@ -73,14 +74,16 @@ impl EvmClient {
             )
             .await?;
 
-        result
-            .as_str()
-            .map(|s| s.to_string())
-            .ok_or_else(|| BulletinError::ChainError("sendRawTransaction returned non-string".into()))
+        result.as_str().map(|s| s.to_string()).ok_or_else(|| {
+            BulletinError::ChainError("sendRawTransaction returned non-string".into())
+        })
     }
 
     /// Get the transaction receipt
-    pub async fn get_transaction_receipt(&self, tx_hash: &str) -> Result<Option<TransactionReceipt>> {
+    pub async fn get_transaction_receipt(
+        &self,
+        tx_hash: &str,
+    ) -> Result<Option<TransactionReceipt>> {
         let result = self
             .rpc_request("eth_getTransactionReceipt", json!([tx_hash]))
             .await?;
@@ -109,11 +112,14 @@ impl EvmClient {
     }
 
     /// Send a precompile transaction: fetch nonce, sign, send, wait for receipt
-    pub async fn send_precompile_tx(&self, to: Address, calldata: Vec<u8>) -> Result<TransactionReceipt> {
-        let signer = self
-            .signer
-            .as_ref()
-            .ok_or_else(|| BulletinError::ChainError("No signer configured for write operation".into()))?;
+    pub async fn send_precompile_tx(
+        &self,
+        to: Address,
+        calldata: Vec<u8>,
+    ) -> Result<TransactionReceipt> {
+        let signer = self.signer.as_ref().ok_or_else(|| {
+            BulletinError::ChainError("No signer configured for write operation".into())
+        })?;
 
         let nonce = self.get_nonce(signer.address()).await?;
         let raw_tx = signer.sign_tx(to, calldata, nonce)?;
@@ -147,10 +153,9 @@ impl EvmClient {
             .await
             .map_err(|e| BulletinError::ChainError(format!("RPC request failed: {}", e)))?;
 
-        let json: Value = response
-            .json()
-            .await
-            .map_err(|e| BulletinError::ChainError(format!("Failed to parse RPC response: {}", e)))?;
+        let json: Value = response.json().await.map_err(|e| {
+            BulletinError::ChainError(format!("Failed to parse RPC response: {}", e))
+        })?;
 
         if let Some(error) = json.get("error") {
             return Err(BulletinError::ChainError(format!("RPC error: {}", error)));

--- a/crates/bulletin/src/hubrs/mod.rs
+++ b/crates/bulletin/src/hubrs/mod.rs
@@ -33,10 +33,7 @@ pub struct HubRsBulletin {
 #[async_trait]
 impl Bulletin for HubRsBulletin {
     async fn register(&self, namespace: String) -> Result<()> {
-        let calldata = IBulletin::registerNamespaceCall {
-            namespace,
-        }
-        .abi_encode();
+        let calldata = IBulletin::registerNamespaceCall { namespace }.abi_encode();
 
         self.client
             .send_precompile_tx(self.precompile_addr, calldata)
@@ -80,31 +77,21 @@ impl Bulletin for HubRsBulletin {
         }
         .abi_encode();
 
-        let result_bytes = self
-            .client
-            .eth_call(self.precompile_addr, calldata)
-            .await?;
+        let result_bytes = self.client.eth_call(self.precompile_addr, calldata).await?;
 
         // ABI-decode the return value: getPost returns (bytes memory)
-        let decoded = IBulletin::getPostCall::abi_decode_returns(&result_bytes)
-            .map_err(|e| {
-                BulletinError::ChainError(format!("Failed to ABI-decode getPost response: {}", e))
-            })?;
+        let decoded = IBulletin::getPostCall::abi_decode_returns(&result_bytes).map_err(|e| {
+            BulletinError::ChainError(format!("Failed to ABI-decode getPost response: {}", e))
+        })?;
 
         let json_bytes: &[u8] = &decoded.0;
 
         if json_bytes.is_empty() {
-            return Err(BulletinError::NotFound {
-                namespace: ns,
-                id,
-            });
+            return Err(BulletinError::NotFound { namespace: ns, id });
         }
 
         let hub_post: HubPost = serde_json::from_slice(json_bytes).map_err(|e| {
-            BulletinError::ParseError(format!(
-                "Failed to parse hub.rs post JSON: {}",
-                e
-            ))
+            BulletinError::ParseError(format!("Failed to parse hub.rs post JSON: {}", e))
         })?;
 
         Ok(BulletinPost {

--- a/crates/bulletin/src/hubrs/signer.rs
+++ b/crates/bulletin/src/hubrs/signer.rs
@@ -15,8 +15,8 @@ pub struct EvmSigner {
 impl EvmSigner {
     /// Create a signer from a hex-encoded private key and chain ID
     pub fn from_hex(hex_key: &str, chain_id: u64) -> Result<Self> {
-        let key_bytes =
-            hex::decode(hex_key).map_err(|e| BulletinError::ChainError(format!("Invalid hex key: {}", e)))?;
+        let key_bytes = hex::decode(hex_key)
+            .map_err(|e| BulletinError::ChainError(format!("Invalid hex key: {}", e)))?;
         let signing_key = k256::ecdsa::SigningKey::from_slice(&key_bytes)
             .map_err(|e| BulletinError::ChainError(format!("Invalid private key: {}", e)))?;
         let signer = PrivateKeySigner::from_signing_key(signing_key);

--- a/crates/bulletin/src/hubrs/tests.rs
+++ b/crates/bulletin/src/hubrs/tests.rs
@@ -72,5 +72,8 @@ fn test_get_post_abi_encoding() {
 #[test]
 fn test_precompile_address() {
     let addr = Address::from(abi::BULLETIN_PRECOMPILE_ADDRESS);
-    assert_eq!(format!("{:?}", addr), "0x0000000000000000000000000000000000000811");
+    assert_eq!(
+        format!("{:?}", addr),
+        "0x0000000000000000000000000000000000000811"
+    );
 }

--- a/crates/bulletin/src/lib.rs
+++ b/crates/bulletin/src/lib.rs
@@ -23,7 +23,7 @@ compile_error!("Features 'dummy' and 'hubrs' are mutually exclusive. Use --no-de
 // Export the selected implementation
 #[cfg(feature = "dummy")]
 pub use dummy::DummyBulletin as BulletinImpl;
-#[cfg(feature = "sourcehub")]
-pub use sourcehub::SourceHubBulletin as BulletinImpl;
 #[cfg(feature = "hubrs")]
 pub use hubrs::HubRsBulletin as BulletinImpl;
+#[cfg(feature = "sourcehub")]
+pub use sourcehub::SourceHubBulletin as BulletinImpl;

--- a/crates/bulletin/src/sourcehub/mod.rs
+++ b/crates/bulletin/src/sourcehub/mod.rs
@@ -69,7 +69,8 @@ impl Bulletin for SourceHubBulletin {
             id: post.id,
             namespace: post.namespace,
             payload: post.payload,
-            proof: post.proof,
+            // Vera's bulletin Post carries no proof field.
+            proof: Vec::new(),
         })
     }
 

--- a/crates/common/src/blockchain/acp.rs
+++ b/crates/common/src/blockchain/acp.rs
@@ -31,7 +31,7 @@ pub struct MsgCreatePolicy {
 }
 
 impl MsgCreatePolicy {
-    pub const TYPE_URL: &'static str = "/sourcehub.acp.MsgCreatePolicy";
+    pub const TYPE_URL: &'static str = "/vera.acp.MsgCreatePolicy";
 
     /// Create a new policy message with YAML format.
     pub fn new_yaml(creator: &str, policy: &str) -> Self {
@@ -71,7 +71,7 @@ pub struct MsgCheckAccess {
 }
 
 impl MsgCheckAccess {
-    pub const TYPE_URL: &'static str = "/sourcehub.acp.MsgCheckAccess";
+    pub const TYPE_URL: &'static str = "/vera.acp.MsgCheckAccess";
 }
 
 /// Direct policy command message.
@@ -93,7 +93,7 @@ pub struct MsgDirectPolicyCmd {
 }
 
 impl MsgDirectPolicyCmd {
-    pub const TYPE_URL: &'static str = "/sourcehub.acp.MsgDirectPolicyCmd";
+    pub const TYPE_URL: &'static str = "/vera.acp.MsgDirectPolicyCmd";
 }
 
 // ============================================================================
@@ -381,7 +381,7 @@ pub struct OperationResult {
 // ============================================================================
 
 /// ABCI request for the VerifyAccessRequest query.
-/// Proto: sourcehub.acp.QueryVerifyAccessRequestRequest
+/// Proto: vera.acp.QueryVerifyAccessRequestRequest
 #[derive(Clone, Message)]
 pub struct QueryVerifyAccessRequestRequest {
     #[prost(string, tag = "1")]
@@ -391,7 +391,7 @@ pub struct QueryVerifyAccessRequestRequest {
 }
 
 /// ABCI response for the VerifyAccessRequest query.
-/// Proto: sourcehub.acp.QueryVerifyAccessRequestResponse
+/// Proto: vera.acp.QueryVerifyAccessRequestResponse
 #[derive(Clone, Message)]
 pub struct QueryVerifyAccessRequestResponse {
     #[prost(bool, tag = "1")]
@@ -474,7 +474,7 @@ pub enum SubjectSelectorKind {
 }
 
 /// gRPC request for FilterRelationships query.
-/// Proto: sourcehub.acp.QueryFilterRelationshipsRequest
+/// Proto: vera.acp.QueryFilterRelationshipsRequest
 #[derive(Clone, Message)]
 pub struct QueryFilterRelationshipsRequest {
     #[prost(string, tag = "1")]
@@ -484,7 +484,7 @@ pub struct QueryFilterRelationshipsRequest {
 }
 
 /// Response from filtering relationships (gRPC).
-/// Proto: sourcehub.acp.QueryFilterRelationshipsResponse
+/// Proto: vera.acp.QueryFilterRelationshipsResponse
 #[derive(Clone, Message)]
 pub struct QueryFilterRelationshipsResponse {
     #[prost(message, repeated, tag = "1")]
@@ -492,7 +492,7 @@ pub struct QueryFilterRelationshipsResponse {
 }
 
 /// A relationship record stored on-chain.
-/// Proto: sourcehub.acp.RelationshipRecord
+/// Proto: vera.acp.RelationshipRecord
 #[derive(Clone, Message)]
 pub struct RelationshipRecord {
     #[prost(string, tag = "1")]
@@ -515,7 +515,7 @@ impl SourceHubClient {
     /// Query a policy by ID.
     pub async fn acp_query_policy(&self, policy_id: &str) -> Result<QueryPolicyResponse> {
         let url = format!(
-            "{}/sourcenetwork/sourcehub/acp/policy/{}",
+            "{}/sourcenetwork/vera/acp/policy/{}",
             self.config().rest_url,
             policy_id
         );
@@ -525,7 +525,7 @@ impl SourceHubClient {
     /// List all policy IDs.
     pub async fn acp_list_policy_ids(&self) -> Result<QueryPolicyIdsResponse> {
         let url = format!(
-            "{}/sourcenetwork/sourcehub/acp/policy_ids",
+            "{}/sourcenetwork/vera/acp/policy_ids",
             self.config().rest_url
         );
         self.rest_get(&url).await
@@ -549,7 +549,7 @@ impl SourceHubClient {
 
         let response_bytes = self
             .abci_query(
-                "/sourcehub.acp.Query/VerifyAccessRequest",
+                "/vera.acp.Query/VerifyAccessRequest",
                 request_bytes,
                 None,
                 false,
@@ -585,7 +585,7 @@ impl SourceHubClient {
         let request_bytes = request.encode_to_vec();
 
         // Query path for gRPC-style ABCI query
-        let path = "/sourcehub.acp.Query/FilterRelationships";
+        let path = "/vera.acp.Query/FilterRelationships";
 
         // Execute ABCI query
         let response_bytes = self.abci_query(path, request_bytes, None, false).await?;

--- a/crates/common/src/blockchain/bulletin.rs
+++ b/crates/common/src/blockchain/bulletin.rs
@@ -28,16 +28,17 @@ pub struct MsgCreatePost {
     /// Post payload data
     #[prost(bytes = "vec", tag = "3")]
     pub payload: Vec<u8>,
-    /// Cryptographic proof (optional)
-    #[prost(bytes = "vec", tag = "4")]
-    pub proof: Vec<u8>,
     /// Artifact for finding post (optional)
+    ///
+    /// Tag 4 was a `proof` field that Vera's `MsgCreatePost` does not have.
+    /// Sending it makes the chain reject the transaction at decode time with
+    /// `errUnknownField "*types.MsgCreatePost": {TagNum: 4}`.
     #[prost(string, tag = "5")]
     pub artifact: String,
 }
 
 impl MsgCreatePost {
-    pub const TYPE_URL: &'static str = "/sourcehub.bulletin.MsgCreatePost";
+    pub const TYPE_URL: &'static str = "/vera.bulletin.MsgCreatePost";
 
     /// Create a new post message.
     pub fn new(creator: &str, namespace: &str, payload: Vec<u8>, artifact: Option<String>) -> Self {
@@ -45,24 +46,6 @@ impl MsgCreatePost {
             creator: creator.to_string(),
             namespace: namespace.to_string(),
             payload,
-            proof: Vec::new(),
-            artifact: artifact.unwrap_or("".to_string()),
-        }
-    }
-
-    /// Create a new post message with proof.
-    pub fn with_proof(
-        creator: &str,
-        namespace: &str,
-        payload: Vec<u8>,
-        proof: Vec<u8>,
-        artifact: Option<String>,
-    ) -> Self {
-        Self {
-            creator: creator.to_string(),
-            namespace: namespace.to_string(),
-            payload,
-            proof,
             artifact: artifact.unwrap_or("".to_string()),
         }
     }
@@ -83,7 +66,7 @@ pub struct MsgRegisterNamespace {
 }
 
 impl MsgRegisterNamespace {
-    pub const TYPE_URL: &'static str = "/sourcehub.bulletin.MsgRegisterNamespace";
+    pub const TYPE_URL: &'static str = "/vera.bulletin.MsgRegisterNamespace";
 
     pub fn new(creator: &str, namespace: &str) -> Self {
         Self {
@@ -112,7 +95,7 @@ pub struct MsgAddCollaborator {
 }
 
 impl MsgAddCollaborator {
-    pub const TYPE_URL: &'static str = "/sourcehub.bulletin.MsgAddCollaborator";
+    pub const TYPE_URL: &'static str = "/vera.bulletin.MsgAddCollaborator";
 
     pub fn new(creator: &str, namespace: &str, collaborator: &str) -> Self {
         Self {
@@ -142,7 +125,7 @@ pub struct MsgRemoveCollaborator {
 }
 
 impl MsgRemoveCollaborator {
-    pub const TYPE_URL: &'static str = "/sourcehub.bulletin.MsgRemoveCollaborator";
+    pub const TYPE_URL: &'static str = "/vera.bulletin.MsgRemoveCollaborator";
 
     pub fn new(creator: &str, namespace: &str, collaborator: &str) -> Self {
         Self {
@@ -158,7 +141,7 @@ impl MsgRemoveCollaborator {
 // ============================================================================
 
 /// Request to read a single post.
-/// Proto: sourcehub.bulletin.QueryPostRequest
+/// Proto: vera.bulletin.QueryPostRequest
 #[derive(Clone, Message)]
 pub struct QueryPostRequest {
     /// Namespace identifier
@@ -170,7 +153,7 @@ pub struct QueryPostRequest {
 }
 
 /// Request to get namespace information.
-/// Proto: sourcehub.bulletin.QueryNamespaceRequest
+/// Proto: vera.bulletin.QueryNamespaceRequest
 #[derive(Clone, Message)]
 pub struct QueryNamespaceRequest {
     /// Namespace identifier
@@ -179,7 +162,7 @@ pub struct QueryNamespaceRequest {
 }
 
 /// Request to list posts in a namespace.
-/// Proto: sourcehub.bulletin.QueryNamespacePostsRequest
+/// Proto: vera.bulletin.QueryNamespacePostsRequest
 #[derive(Clone, Message)]
 pub struct QueryNamespacePostsRequest {
     /// Namespace identifier
@@ -191,7 +174,7 @@ pub struct QueryNamespacePostsRequest {
 }
 
 /// Request to iterate posts matching a glob pattern.
-/// Proto: sourcehub.bulletin.QueryIterateGlobRequest
+/// Proto: vera.bulletin.QueryIterateGlobRequest
 #[derive(Clone, Message)]
 pub struct QueryIterateGlobRequest {
     /// Namespace identifier
@@ -227,7 +210,7 @@ pub struct PageRequest {
 // ============================================================================
 
 /// Response containing a single post.
-/// Proto: sourcehub.bulletin.QueryPostResponse
+/// Proto: vera.bulletin.QueryPostResponse
 #[derive(Clone, Message)]
 pub struct QueryPostResponse {
     /// The post data
@@ -236,7 +219,7 @@ pub struct QueryPostResponse {
 }
 
 /// Response containing namespace information.
-/// Proto: sourcehub.bulletin.QueryNamespaceResponse
+/// Proto: vera.bulletin.QueryNamespaceResponse
 #[derive(Clone, Message)]
 pub struct QueryNamespaceResponse {
     /// The namespace data
@@ -245,7 +228,7 @@ pub struct QueryNamespaceResponse {
 }
 
 /// Response containing posts in a namespace.
-/// Proto: sourcehub.bulletin.QueryNamespacePostsResponse
+/// Proto: vera.bulletin.QueryNamespacePostsResponse
 #[derive(Clone, Message)]
 pub struct QueryNamespacePostsResponse {
     /// List of posts
@@ -257,7 +240,7 @@ pub struct QueryNamespacePostsResponse {
 }
 
 /// Response from glob iteration.
-/// Proto: sourcehub.bulletin.QueryIterateGlobResponse
+/// Proto: vera.bulletin.QueryIterateGlobResponse
 #[derive(Clone, Message)]
 pub struct QueryIterateGlobResponse {
     /// Matching posts
@@ -281,7 +264,7 @@ pub struct PageResponse {
 // ============================================================================
 
 /// A post stored on the bulletin board.
-/// Proto: sourcehub.bulletin.Post
+/// Proto: vera.bulletin.Post
 #[derive(Clone, Message)]
 pub struct Post {
     /// Post identifier
@@ -296,13 +279,10 @@ pub struct Post {
     /// Post payload data
     #[prost(bytes = "vec", tag = "4")]
     pub payload: Vec<u8>,
-    /// Cryptographic proof
-    #[prost(bytes = "vec", tag = "5")]
-    pub proof: Vec<u8>,
 }
 
 /// A namespace in the bulletin module.
-/// Proto: sourcehub.bulletin.Namespace
+/// Proto: vera.bulletin.Namespace
 #[derive(Clone, Message)]
 pub struct Namespace {
     /// Namespace identifier
@@ -314,7 +294,7 @@ pub struct Namespace {
 }
 
 /// A collaborator record.
-/// Proto: sourcehub.bulletin.Collaborator
+/// Proto: vera.bulletin.Collaborator
 #[derive(Clone, Message)]
 pub struct Collaborator {
     /// Namespace identifier
@@ -343,7 +323,7 @@ impl SourceHubClient {
         };
 
         let request_bytes = request.encode_to_vec();
-        let path = "/sourcehub.bulletin.Query/Post";
+        let path = "/vera.bulletin.Query/Post";
 
         let response_bytes = match self.abci_query(path, request_bytes, None, false).await {
             Ok(bytes) => bytes,
@@ -365,7 +345,7 @@ impl SourceHubClient {
         };
 
         let request_bytes = request.encode_to_vec();
-        let path = "/sourcehub.bulletin.Query/Namespace";
+        let path = "/vera.bulletin.Query/Namespace";
 
         let response_bytes = self.abci_query(path, request_bytes, None, false).await?;
 
@@ -386,7 +366,7 @@ impl SourceHubClient {
         };
 
         let request_bytes = request.encode_to_vec();
-        let path = "/sourcehub.bulletin.Query/NamespacePosts";
+        let path = "/vera.bulletin.Query/NamespacePosts";
 
         let response_bytes = self.abci_query(path, request_bytes, None, false).await?;
 
@@ -406,7 +386,7 @@ impl SourceHubClient {
         };
 
         let request_bytes = request.encode_to_vec();
-        let path = "/sourcehub.bulletin.Query/IterateGlob";
+        let path = "/vera.bulletin.Query/IterateGlob";
 
         let response_bytes = self.abci_query(path, request_bytes, None, false).await?;
 
@@ -460,7 +440,12 @@ impl SourceHubClient {
         .await
     }
 
-    /// Create a post with proof in a namespace.
+    /// Create a post in a namespace, given a proof the caller holds.
+    ///
+    /// Vera's `MsgCreatePost` carries no proof field, so the proof is not
+    /// persisted on chain. A caller passing a non-empty proof is warned rather
+    /// than silently ignored, because a dropped proof is not visible in the
+    /// result.
     pub async fn bulletin_create_post_with_proof(
         &self,
         namespace: &str,
@@ -472,7 +457,15 @@ impl SourceHubClient {
             .signer()
             .ok_or_else(|| BlockchainError::Signing("No signer configured".to_string()))?;
 
-        let msg = MsgCreatePost::with_proof(&signer.address(), namespace, payload, proof, artifact);
+        if !proof.is_empty() {
+            eprintln!(
+                "bulletin_create_post_with_proof: dropping a {}-byte proof for namespace {}: \
+                 Vera's MsgCreatePost has no proof field",
+                proof.len(),
+                namespace
+            );
+        }
+        let msg = MsgCreatePost::new(&signer.address(), namespace, payload, artifact);
 
         self.broadcast_proto_msg_with_gas(
             MsgCreatePost::TYPE_URL,
@@ -522,5 +515,63 @@ impl SourceHubClient {
             self.config().gas_multiplier,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod message_shape_tests {
+    use super::{MsgCreatePost, MsgRegisterNamespace};
+    use prost::Message;
+
+    /// A permissive view of `MsgCreatePost` that keeps the removed field 4, so
+    /// a test can prove the encoder never writes it.
+    #[derive(Clone, PartialEq, Message)]
+    struct PostWithLegacyProof {
+        #[prost(string, tag = "1")]
+        creator: String,
+        #[prost(string, tag = "2")]
+        namespace: String,
+        #[prost(bytes = "vec", tag = "3")]
+        payload: Vec<u8>,
+        #[prost(bytes = "vec", tag = "4")]
+        legacy_proof: Vec<u8>,
+        #[prost(string, tag = "5")]
+        artifact: String,
+    }
+
+    /// Vera's `MsgCreatePost` has no field 4. Sending one makes the chain
+    /// reject the whole transaction at decode time with
+    /// `errUnknownField "*types.MsgCreatePost": {TagNum: 4}`, which surfaces as
+    /// a failed DKG rather than as a bulletin error, so it is worth pinning.
+    #[test]
+    fn create_post_never_encodes_the_removed_proof_field() {
+        let msg = MsgCreatePost::new(
+            "vera1creator",
+            "orbis",
+            b"ring payload".to_vec(),
+            Some("session-1".to_string()),
+        );
+        let encoded = msg.encode_to_vec();
+
+        let decoded = PostWithLegacyProof::decode(encoded.as_slice()).expect("decode");
+        assert!(
+            decoded.legacy_proof.is_empty(),
+            "field 4 must not be on the wire"
+        );
+        assert_eq!(decoded.creator, "vera1creator");
+        assert_eq!(decoded.namespace, "orbis");
+        assert_eq!(decoded.payload, b"ring payload");
+        assert_eq!(decoded.artifact, "session-1");
+    }
+
+    /// The type URLs name Vera's proto package. The chain routes on these
+    /// exactly, so a stale `sourcehub.` prefix is an unroutable transaction.
+    #[test]
+    fn type_urls_are_vera_qualified() {
+        assert_eq!(MsgCreatePost::TYPE_URL, "/vera.bulletin.MsgCreatePost");
+        assert_eq!(
+            MsgRegisterNamespace::TYPE_URL,
+            "/vera.bulletin.MsgRegisterNamespace"
+        );
     }
 }

--- a/crates/common/src/blockchain/config.rs
+++ b/crates/common/src/blockchain/config.rs
@@ -23,7 +23,7 @@ impl Default for GasPrice {
 /// Configuration for connecting to a SourceHub chain.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainConfig {
-    /// Chain ID (e.g., "sourcehub-testnet")
+    /// Chain ID (e.g., "vera-testnet")
     pub chain_id: String,
 
     /// Tendermint RPC URL (e.g., "http://localhost:26657")
@@ -35,7 +35,7 @@ pub struct ChainConfig {
     /// gRPC URL (e.g., "http://localhost:9090")
     pub grpc_url: String,
 
-    /// Account address prefix (e.g., "source")
+    /// Account address prefix (e.g., "vera")
     pub account_prefix: String,
 
     /// Default gas limit for transactions
@@ -57,11 +57,11 @@ impl ChainConfig {
     /// Configuration for local development (default Docker setup).
     pub fn local() -> Self {
         Self {
-            chain_id: "sourcehub-localnet".to_string(),
+            chain_id: "vera-localnet".to_string(),
             rpc_url: "http://localhost:26657".to_string(),
             rest_url: "http://localhost:1317".to_string(),
             grpc_url: "http://localhost:9090".to_string(),
-            account_prefix: "source".to_string(),
+            account_prefix: "vera".to_string(),
             default_gas_limit: 300_000,
             gas_price: GasPrice::default(),
             gas_multiplier: 1.2,

--- a/crates/common/src/blockchain/signer.rs
+++ b/crates/common/src/blockchain/signer.rs
@@ -210,7 +210,7 @@ mod tests {
         let address = signer.address();
 
         // Address should be bech32 encoded with the configured prefix
-        assert!(address.starts_with("source1"));
+        assert!(address.starts_with("vera1"));
         println!("Test address: {}", address);
     }
 
@@ -223,6 +223,6 @@ mod tests {
         let signer = TxSigner::new(&key_bytes, config).unwrap();
         let address = signer.address();
 
-        assert!(address.starts_with("source1"));
+        assert!(address.starts_with("vera1"));
     }
 }

--- a/crates/common/src/blockchain/tests.rs
+++ b/crates/common/src/blockchain/tests.rs
@@ -66,8 +66,8 @@ fn test_signer_creation() {
     let address = signer.address();
     println!("Signer address: {}", address);
 
-    // Address should be bech32 encoded with "source" prefix
-    assert!(address.starts_with("source1"));
+    // Address should be bech32 encoded with "vera" prefix
+    assert!(address.starts_with("vera1"));
 }
 
 /// Test ChainConfig builder.

--- a/crates/crypto/src/bls12_381/tests/sign_tests.rs
+++ b/crates/crypto/src/bls12_381/tests/sign_tests.rs
@@ -112,3 +112,56 @@ fn test_threshold_signing_different_share_subsets_same_signature() {
     assert!(signer.verify(&aggregate_pk, msg, &sig1).is_ok());
     assert!(signer.verify(&aggregate_pk, msg, &sig2).is_ok());
 }
+
+// ============================================================================
+// Derivation: the signing scalar and the PRE capability scalar are different
+// ============================================================================
+
+/// A key derived for signing is not the key derived for proxy re-encryption.
+///
+/// Both traits expose `derive_public_key` over the same ring key and label, but
+/// they use different scalars. Advertising one and signing with the other
+/// yields a signature no verifier accepts, and nothing fails until a peer
+/// rejects the block, so the distinction is pinned here.
+#[test]
+fn sign_derivation_differs_from_pre_capability_derivation() {
+    use crate::bls12_381::pre::ThresholdDealerNode;
+    use crate::r#trait::ThresholdDealer as _;
+
+    let sk = Fr::rand(&mut OsRng);
+    let ring_pk: G1Affine = (G1Projective::generator() * sk).into();
+    let derivation = b"acme-corp";
+
+    let for_signing =
+        <ThresholdBlsSigner as ThresholdSigner>::derive_public_key(&ring_pk, derivation, None)
+            .expect("signing derivation");
+    let for_capability = ThresholdDealerNode::derive_public_key(&ring_pk, derivation)
+        .expect("capability derivation");
+
+    assert_ne!(
+        for_signing, for_capability,
+        "the two derivations must stay distinguishable; if they ever coincide, \
+         the RPC that advertises a signing key can no longer be checked by this test"
+    );
+}
+
+/// The signing derivation is deterministic and label-separating: the same label
+/// gives the same key, a different label a different one.
+#[test]
+fn sign_derivation_is_deterministic_and_label_separating() {
+    let sk = Fr::rand(&mut OsRng);
+    let ring_pk: G1Affine = (G1Projective::generator() * sk).into();
+
+    let acme =
+        <ThresholdBlsSigner as ThresholdSigner>::derive_public_key(&ring_pk, b"acme-corp", None)
+            .expect("acme derivation");
+    let acme_again =
+        <ThresholdBlsSigner as ThresholdSigner>::derive_public_key(&ring_pk, b"acme-corp", None)
+            .expect("acme derivation again");
+    let globex =
+        <ThresholdBlsSigner as ThresholdSigner>::derive_public_key(&ring_pk, b"globex-inc", None)
+            .expect("globex derivation");
+
+    assert_eq!(acme, acme_again, "the same label must derive the same key");
+    assert_ne!(acme, globex, "two tenants' labels must not derive one key");
+}


### PR DESCRIPTION
Against a current Vera chain (github.com/sourcenetwork/vera, formerly SourceHub) this branch's base cannot complete a DKG, and the keys it advertises for threshold signing do not verify. Three separate defects, all found by running the stack end to end.

## What changed

**1. `DerivePublicKey` advertised a key nothing signs under.** The RPC returned `ThresholdDealer::derive_public_key`, the PRE capability scalar, while a threshold signature is produced under `ThresholdSigner::derive_public_key`, the signing scalar. A client that publishes the advertised key, as DefraDB does when it stamps a block signature, produces blocks no peer can verify. Nothing fails at signing time: the mismatch surfaces on a peer as `BLST_VERIFY_FAIL` after the write was acknowledged. Both the derive RPC and the key reported in the sign response now use the signing scalar.

**2. The requested derivation was dropped on the authenticated and access-decision paths.** `SignContext::Authenticated` and `SignContext::AccessDecision` carried no derivation, so both the coordinator and every responder signed from the ring root key while the caller asked for a label. The variants now carry `derivation` and both paths honour it.

**3. Vera wire types.** `/vera.acp.*` and `/vera.bulletin.*` type URLs and query paths, `vera` bech32 prefix, `vera-localnet` default chain id, and `MsgCreatePost` without the removed field 4 (Vera's message has creator, namespace, payload, artifact; sending field 4 makes the chain reject the transaction at decode time with `errUnknownField {TagNum: 4}`, which shows up as a DKG that never posts its ring payload). `bulletin_create_post_with_proof` now says out loud that Vera stores no proof rather than dropping one silently.

**4. `--chain-id` on orbis-node.** The chain id was hardcoded to `sourcehub-localnet` with no flag. It is part of every signed transaction, so a node on any other chain fails signature verification on every send.

## Tests

- `crates/crypto`: the signing derivation and the PRE capability derivation are distinct, and the signing derivation is deterministic and label-separating.
- `crates/common`: `MsgCreatePost` never encodes the removed proof field, checked by decoding into a permissive struct that keeps field 4; type URLs are Vera-qualified.
- `cargo test -p crypto` (10 passed) and `cargo test -p common --lib` (7 passed) pass. The four `blockchain::tests` failures and the two `bulletin::sourcehub::tests` failures on this branch need Docker Compose, are the set CI excludes with `-E "not (...)"`, and fail identically before and after.
- `cargo fmt --all -- --check` is clean.

**CI does not run on this PR.** `.github/workflows/rust.yml` triggers only on pull requests into `main` or `develop`, and this one targets `jack/integration-testing` (see Base below), so no workflow is dispatched. I ran the lint and clippy gates locally instead. `cargo clippy --all-targets -- -D warnings` reports two `bool_assert_comparison` errors in `crates/local-storage/src/tests.rs:21` and `:28`; both are on the base branch, from #256, and are untouched here. They will fail the clippy gate whenever this base reaches `develop`.

## Verified end to end

With these fixes plus the companion DefraDB change ([defradb.rs#1681](https://github.com/sourcenetwork/defradb.rs/pull/1681)), a `verad` devnet, a 3-node ring at threshold 2, and up to 35 DefraDB cells complete DKG with the ring payload on Vera's bulletin, and ring-signed documents replicate and verify on a peer. In [backbone#30](https://github.com/sourcenetwork/backbone/pull/30)'s `tests/gents_cloud` suite, 13 of 13 scenarios pass across 32 tenants, each tenant's writes ring-signed, with 223 chain transactions committed and none failed. The ring's signing call with a Vera ACP check measured 54 ms. A probe in that suite asserts directly that a `utility-sign` signature verifies under the key `derive-public-key` advertises, using the same blst primitive and domain tag DefraDB verifies blocks with. It fails on this branch's base and passes here.

## Base

Branched from `jack/integration-testing` rather than `develop`: DefraDB's Orbis signer calls the UtilityService, which exists only on that branch. `develop` is already Vera-native but has no UtilityService, so it cannot serve `--signer-type orbis` today. Retargeting is fine if the utility path lands on `develop` first.

