### PR TITLE
PoC: LaKey-derived keys with existing Orbis PRE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "sha3",
  "subtle",
  "thiserror 1.0.69",
  "zeroize",
@@ -3175,6 +3176,15 @@ dependencies = [
  "once_cell",
  "sha2 0.10.9",
  "signature 2.2.0",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -5459,6 +5469,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.11.0-rc.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+sha3 = "0.10"
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.6.0"
 
@@ -52,3 +53,7 @@ required-features = ["test-helpers"]
 
 [lints]
 workspace = true
+
+[[example]]
+name = "lakey_pre"
+required-features = ["decaf377"]

--- a/crates/crypto/examples/lakey_pre.rs
+++ b/crates/crypto/examples/lakey_pre.rs
@@ -1,0 +1,255 @@
+//! Synthetic MPC-share interoperability test, not a deployed Orbis service.
+use ark_ff::PrimeField;
+use crypto::r#trait::{DistKeyShare, PriShare, PubPoly, ThresholdDealer};
+use crypto::{CiphertextContext, CryptoSerialize, PreImpl, PubPolyImpl};
+use decaf377::{Element, Fr};
+use rand_core::OsRng;
+use serde_json::json;
+use std::{fs, path::Path, time::Instant};
+
+fn public_polynomial(shares: &[Fr]) -> PubPolyImpl {
+    let mut commits = vec![Element::default(); shares.len()];
+    for (i, share) in shares.iter().enumerate() {
+        let x = Fr::from(i as u64 + 1);
+        let mut coeff = vec![Fr::from(1u64)];
+        let mut denom = Fr::from(1u64);
+        for j in 0..shares.len() {
+            if i == j {
+                continue;
+            }
+            let y = Fr::from(j as u64 + 1);
+            let mut next = vec![Fr::from(0u64); coeff.len() + 1];
+            for (k, c) in coeff.iter().enumerate() {
+                next[k] -= *c * y;
+                next[k + 1] += c;
+            }
+            coeff = next;
+            denom *= x - y;
+        }
+        let point = Element::GENERATOR * (*share * denom.inverse().unwrap());
+        for (target, c) in commits.iter_mut().zip(coeff) {
+            *target += point * c;
+        }
+    }
+    PubPolyImpl { commits }
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    assert!(args.len() == 5, "usage: lakey_pre <synthetic Persistence directory> <nodes> <threshold> <public-reference.json>");
+    let dir = Path::new(&args[1]);
+    let n: usize = args[2].parse().unwrap();
+    let t: usize = args[3].parse().unwrap();
+    let reference = Path::new(&args[4]);
+    assert!(t >= 2 && t <= n && n <= 32);
+    // Files are synthetic local test fixtures. This process can read all nodes;
+    // production must keep each share with its node and use authenticated handoff.
+    let mut by_node = Vec::new();
+    let mut masters = Vec::new();
+    let mut rbytes = [0u8; 33];
+    rbytes[32] = 1;
+    let r_inv = Fr::from_le_bytes_mod_order(&rbytes).inverse().unwrap();
+    for i in 0..n {
+        let path = dir.join(format!("Transactions-P{i}.data"));
+        let bytes = fs::read(&path).unwrap();
+        let header = 8 + u64::from_le_bytes(bytes[..8].try_into().unwrap()) as usize;
+        assert_eq!(
+            bytes.len(),
+            header + (512 + 4) * 32,
+            "unexpected fixture format"
+        );
+        let mut shares = Vec::new();
+        masters.push(
+            (0..512)
+                .map(|j| {
+                    Fr::from_le_bytes_mod_order(&bytes[header + j * 32..header + (j + 1) * 32])
+                        * r_inv
+                })
+                .collect::<Vec<_>>(),
+        );
+        for j in 0..4 {
+            let off = header + (512 + j) * 32;
+            shares.push(Fr::from_le_bytes_mod_order(&bytes[off..off + 32]) * r_inv);
+        }
+        by_node.push(shares);
+        // Remove the bounded synthetic handoff slots. Only 512 master shares remain.
+        fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_len((header + 512 * 32) as u64)
+            .unwrap();
+    }
+    let polys: Vec<_> = (0..4)
+        .map(|slot| {
+            let shares: Vec<_> = by_node.iter().map(|v| v[slot]).collect();
+            let p = public_polynomial(&shares[..t]);
+            for (i, s) in shares.iter().enumerate() {
+                assert_eq!(p.eval(i as u32 + 1), Element::GENERATOR * (*s));
+            }
+            p
+        })
+        .collect();
+    // Independent clear reference on synthetic fixtures ONLY: catches incorrect
+    // modulus, Montgomery decoding, byte ordering, and public-matrix expansion.
+    let mut master = vec![Fr::from(0u64); 512];
+    for i in 0..t {
+        let x = Fr::from(i as u64 + 1);
+        let mut coeff = Fr::from(1u64);
+        for j in 0..t {
+            if i != j {
+                let y = Fr::from(j as u64 + 1);
+                coeff *= -y * (x - y).inverse().unwrap();
+            }
+        }
+        for j in 0..512 {
+            master[j] += masters[i][j] * coeff;
+        }
+    }
+    let logq: usize = 32;
+    let stat: usize = 128;
+    let logp = if logq == 12 { 8 } else { 24 };
+    let rows = (251 + stat + logp - 1) / logp;
+    let ints: Vec<u128> = master
+        .iter()
+        .map(|v| {
+            let limbs = v.into_bigint();
+            assert!(limbs.0[1..].iter().all(|v| *v == 0));
+            let value = limbs.0[0] as u128;
+            assert!(value < (1u128 << logq));
+            value
+        })
+        .collect();
+    for (slot, identity) in [
+        "chain1/ring1/epoch1/named/Alice/amount",
+        "chain1/ring1/epoch1/named/Bob/amount",
+        "chain1/ring1/epoch1/named/Alice/sender",
+        "chain1/ring1/epoch1/general/amount",
+    ]
+    .iter()
+    .enumerate()
+    {
+        use sha3::digest::{ExtendableOutput, Update, XofReader};
+        let mut h = sha3::Shake256::default();
+        h.update(b"orbis-lakey-poc-v1\0");
+        h.update(identity.as_bytes());
+        let mut data = vec![0u8; rows * 512 * 4];
+        h.finalize_xof().read(&mut data);
+        let mut expected = Fr::from(0u64);
+        let mut weight = Fr::from(1u64);
+        for row in 0..rows {
+            let mut dot = 0u128;
+            for j in 0..512 {
+                let off = (row * 512 + j) * 4;
+                let a = u32::from_le_bytes(data[off..off + 4].try_into().unwrap()) as u128
+                    & ((1u128 << logq) - 1);
+                dot += a * ints[j];
+            }
+            let rounded = (dot & ((1u128 << logq) - 1)) >> (logq - logp);
+            expected += Fr::from(rounded as u64) * weight;
+            weight *= Fr::from(1u64 << logp);
+        }
+        assert_eq!(
+            polys[slot].commits[0],
+            Element::GENERATOR * expected,
+            "independent LaKey reference mismatch"
+        );
+    }
+    for i in 0..4 {
+        for j in i + 1..4 {
+            assert_ne!(polys[i].commits[0], polys[j].commits[0]);
+        }
+    }
+    let public_keys: Vec<_> = polys
+        .iter()
+        .map(|p| p.commits[0].to_bytes().unwrap())
+        .collect();
+    if reference.exists() {
+        assert_eq!(
+            public_keys,
+            serde_json::from_slice::<Vec<Vec<u8>>>(&fs::read(reference).unwrap()).unwrap(),
+            "derived keys changed across restart/refresh"
+        );
+    } else {
+        fs::write(reference, serde_json::to_vec(&public_keys).unwrap()).unwrap();
+    }
+    let pre = PreImpl::new();
+    let reader = Fr::rand(&mut OsRng);
+    let reader_pk = Element::GENERATOR * reader;
+    let pop = PreImpl::prove_reader_key(&reader, &reader_pk).unwrap();
+    let start = Instant::now();
+    for encrypted_scope in 0..4 {
+        let context = CiphertextContext {
+            ring_pk: public_keys[encrypted_scope].clone(),
+            policy_id: "synthetic-policy".into(),
+            resource: "synthetic-payment".into(),
+            permission: "audit".into(),
+            tier: Some(encrypted_scope.to_string()),
+            timestamp: None,
+            salt: None,
+        };
+        let plaintext = b"synthetic disclosed value";
+        let (epk, secret, encryption_proof) = PreImpl::encrypt_secret(
+            &polys[encrypted_scope].commits[0],
+            plaintext,
+            None,
+            &context,
+        )
+        .unwrap();
+        PreImpl::verify_encryption(&encryption_proof, &context, &secret).unwrap();
+        let mut opened = Vec::new();
+        // Audit the same ciphertext under each scope, including unrelated people.
+        for scope in 0..4 {
+            let mut replies = Vec::new();
+            for (i, shares) in by_node.iter().take(t).enumerate() {
+                let key = DistKeyShare {
+                    pri_share: PriShare {
+                        i: i as u32 + 1,
+                        v: shares[scope],
+                    },
+                };
+                // The LaKey output is already the effective key. No public derivation.
+                let reply = pre
+                    .reencrypt(&key, &secret, &reader_pk, &pop, None)
+                    .unwrap();
+                pre.verify(&reader_pk, &polys[scope], &epk, &reply, None)
+                    .unwrap();
+                assert!(pre
+                    .verify(&reader_pk, &polys[(scope + 1) % 4], &epk, &reply, None)
+                    .is_err());
+                assert!(pre
+                    .verify(
+                        &reader_pk,
+                        &polys[scope],
+                        &(epk + Element::GENERATOR),
+                        &reply,
+                        None
+                    )
+                    .is_err());
+                replies.push(reply.share.clone());
+            }
+            assert!(pre.recover(&replies[..t - 1], t, n).unwrap().is_none());
+            let result = pre.recover(&replies, t, n).unwrap().unwrap();
+            let decrypted = PreImpl::decrypt_secret(
+                &polys[scope].commits[0],
+                &result,
+                &reader,
+                &secret,
+                &context,
+            );
+            if scope == encrypted_scope {
+                assert_eq!(decrypted.unwrap(), plaintext);
+            } else {
+                assert!(decrypted.is_err(), "unrelated person or field decrypted");
+            }
+            opened.push(result - polys[scope].commits[0] * reader);
+        }
+        for i in 1..4 {
+            assert_ne!(opened[0], opened[i]);
+        }
+    }
+    println!(
+        "{}",
+        json!({"case":"LaKey MPC shares into pinned Orbis Decaf377 PRE","nodes":n,"threshold":t,"ciphertexts":4,"independent_scopes":4,"seconds":start.elapsed().as_secs_f64(),"persistent_master_scalar_shares_per_node":512,"clear_key_output":false,"fixture_reference_reconstructs_synthetic_master_in_test_process":true,"checks":"independent clear LaKey reference, polynomial consistency, restart/refresh public keys, DLEQ, wrong key/field/ephemeral point, insufficient shares, wrong-scope plaintext decryption"})
+    );
+}

--- a/scripts/lakey/CONFIG.mine.macos
+++ b/scripts/lakey/CONFIG.mine.macos
@@ -1,0 +1,4 @@
+MY_CFLAGS = -I/opt/homebrew/include -I/opt/homebrew/opt/openssl@3/include
+MY_LDLIBS = -L/opt/homebrew/lib -L/opt/homebrew/opt/openssl@3/lib
+GDEBUG =
+MY_CFLAGS += -DNO_MIXED_CIRCUITS

--- a/scripts/lakey/README.md
+++ b/scripts/lakey/README.md
@@ -1,0 +1,124 @@
+# LaKey → existing Orbis PRE
+
+This example tests whether LaKey can derive independent Decaf377 key shares
+from fixed per-node master state and pass those shares into existing Orbis PRE.
+It changes no production library, node API, or authorization behavior.
+
+Each node retains 512 master scalar shares (16 KiB, plus a file header),
+independent of the number of identities. Four synthetic identities distinguish
+Alice/Bob, amount/sender, and named/general scopes. Derived shares are transient;
+PRE receives the derived key directly with `derivation = None`. Public keys must
+be registered for encryptors: they cannot compute them from a public master key.
+
+The MPC backend is the published LaKey research implementation, pinned below.
+The example checks its output against an independent clear computation, builds
+public polynomial commitments, and runs Orbis encryption, PRE share verification,
+reconstruction, and decryption. It scans each ciphertext under all four scopes;
+only the matching scope decrypts. Wrong public commitments, changed ephemeral
+points, and insufficient shares are rejected. Restart and same-committee refresh
+must preserve all derived public keys.
+
+## Test boundary
+
+**Use synthetic keys only.** The Rust driver reads every local node's fixture
+and reconstructs the synthetic master for its independent reference check. It
+is not production node isolation or a deployed Orbis ring. MPC itself runs real
+malicious-Shamir processes with live preprocessing and TLS. No fake preprocessing
+is used. This is an interoperability experiment, not a security proof of LaKey,
+its parameter selection, or a complete Shieldd integration.
+
+The reader supports the pinned backend's 64-bit little-endian Montgomery fixture
+format. It removes the four transient derived-share slots after reading them.
+The public reference file contains public keys only; retain it across restart
+and refresh, and use a new file for a new master.
+
+## Reproduction
+
+Run heavy commands sequentially. The tested macOS ARM setup uses Homebrew GMP,
+Boost, libsodium, and OpenSSL. Adapt dependency paths on other systems. Use a
+fresh dependency checkout; never point this at operational ring state.
+
+```sh
+orbis_dir=/absolute/path/orbis-poc-lakey
+mpc_dir=/absolute/path/MP-SPDZ-lakey
+export CARGO_BUILD_JOBS=2 RAYON_NUM_THREADS=2
+umask 077
+
+git clone --branch lattice-prf https://github.com/MetaMask/MP-SPDZ.git "$mpc_dir"
+cd "$mpc_dir"
+git checkout 7a9efcadf134263a94cd0548456e60011a7d4492
+git submodule update --init deps/simde
+git apply "$orbis_dir/scripts/lakey/macos.patch"
+cp "$orbis_dir/scripts/lakey/CONFIG.mine.macos" CONFIG.mine
+make -j2 malicious-shamir-party.x
+bash Scripts/setup-ssl.sh 5
+chmod 600 Player-Data/*.key
+
+for mode in init derive refresh; do
+    python3 "$orbis_dir/scripts/lakey/prepare.py" . --mode "$mode"
+    ./compile.py -O -g 256 "poc_lakey_$mode"
+done
+
+cd "$orbis_dir"
+cargo build -p crypto --example lakey_pre --no-default-features --features decaf377
+cd "$mpc_dir"
+scalar_prime=2111115437357092606062206234695386632838870926408408195193685246394721360383
+PLAYERS=5 THRESHOLD=2 bash Scripts/mal-shamir.sh poc_lakey_init --prime "$scalar_prime" -S 128
+for mode in derive derive refresh; do
+    PLAYERS=5 THRESHOLD=2 bash Scripts/mal-shamir.sh "poc_lakey_$mode" --prime "$scalar_prime" -S 128
+    "$orbis_dir/target/debug/examples/lakey_pre" "$mpc_dir/Persistence" 5 3 "$mpc_dir/public-reference.json"
+done
+```
+
+`THRESHOLD=2` is the MPC degree/corruption bound: reconstruction uses three
+shares. All five MPC participants are online in this experiment; this does not
+establish derivation availability with only three live nodes. Each repeated
+execution starts fresh processes. Refresh adds fresh sharings of zero; it tests
+same-committee key stability, not membership migration or secure erasure.
+
+Parameters are REG32, dimension 512, 24 retained bits per row, and 128-bit
+statistical settings. The runtime prime is the Decaf377 scalar field. The `-g 256`
+compiler path uses bounded integer conversions; do not substitute `-P` without
+checking conversion cost and bounds. The macOS patch adapts the old research fork
+to current GMP/Boost. `NO_MIXED_CIRCUITS` disables its unused binary backend;
+arithmetic malicious checks remain enabled. This patch needs upstream review.
+
+## Work needed before production integration
+
+- Provision, protect, back up, and refresh committee master shares. Define
+  recovery and committee membership changes.
+- Replace these four compiled fixtures with a fixed derivation program and
+  canonical, domain-separated identities. Never accept caller-chosen matrices.
+- Keep each derived share on its node. Authenticate public polynomial
+  commitments and bind registered public keys to the exact identity and epoch.
+- Add Orbis request routing and authorization for the derived key. Enforce ACP,
+  recipient authorization, replay protection, and accepted-ciphertext binding.
+  None of these service checks are provided by this example.
+- Review LaKey parameters and implementation, side channels, erasure, concurrency,
+  and abort/recovery behavior. Measure wider committees before selecting one;
+  user count alone does not determine committee size.
+
+The existing PRE functions accept the derived shares without algorithm changes.
+Production integration still requires node orchestration and authenticated key
+registration. This example does not make the existing public scalar derivation
+safe for person-scoped access; it bypasses that derivation entirely.
+
+[LaKey implementation](https://github.com/MetaMask/MP-SPDZ/tree/7a9efcadf134263a94cd0548456e60011a7d4492)
+and [comparison experiments](https://github.com/mizufinance/shieldd/blob/ca88d386c34acd83560f4f44076b68a6440f7cb0/experiments/orbis-keys/REPORT.md).
+
+## Validation recorded for this PoC
+
+On macOS ARM, against Orbis base `4f9d23c6`:
+
+- The Decaf377 example built; all 32 crypto library tests passed.
+- Real five-process malicious-Shamir initialization, derivation, restart, and
+  refresh passed with live preprocessing at the exact Decaf377 scalar modulus.
+- All three Rust interoperability runs passed the clear reference and negative
+  checks. Derived public keys stayed unchanged across restart and refresh.
+- The final debug-mode PRE/encryption/decryption checks took approximately
+  0.77 seconds for four ciphertexts scanned under four scopes. This excludes MPC
+  derivation and is not a production latency benchmark.
+- No new swap usage was observed. Rust formatting and Python syntax checks passed.
+
+No live Orbis node API, ACP, Shieldd transaction circuit, browser/WASM, release
+build, or production deployment check ran for this example-only PR.

--- a/scripts/lakey/macos.patch
+++ b/scripts/lakey/macos.patch
@@ -1,0 +1,138 @@
+diff --git a/CONFIG b/CONFIG
+index 6d5f0f1..8d2d5d7 100644
+--- a/CONFIG
++++ b/CONFIG
+@@ -66,9 +66,9 @@ endif
+ # Default for MAX_MOD_SZ is 10, which suffices for all Overdrive protocols
+ # MOD = -DMAX_MOD_SZ=10 -DGFP_MOD_SZ=5
+ 
+-LDLIBS = -lmpirxx -lmpir -lsodium $(MY_LDLIBS)
++LDLIBS = -lgmpxx -lgmp -lsodium $(MY_LDLIBS)
+ LDLIBS +=  -Wl,-rpath -Wl,$(CURDIR)/local/lib -L$(CURDIR)/local/lib
+-LDLIBS += -lboost_system -lssl -lcrypto
++LDLIBS += -lssl -lcrypto
+ 
+ CFLAGS += -I./local/include
+ 
+diff --git a/Math/Z2k.h b/Math/Z2k.h
+index e8d2ba5..0415537 100644
+--- a/Math/Z2k.h
++++ b/Math/Z2k.h
+@@ -6,7 +6,7 @@
+ #ifndef MATH_Z2K_H_
+ #define MATH_Z2K_H_
+ 
+-#include <mpirxx.h>
++#include <gmpxx.h>
+ #include <string>
+ using namespace std;
+ 
+diff --git a/Math/bigint.h b/Math/bigint.h
+index 2a92939..39edf46 100644
+--- a/Math/bigint.h
++++ b/Math/bigint.h
+@@ -5,7 +5,7 @@
+ using namespace std;
+ 
+ #include <stddef.h>
+-#include <mpirxx.h>
++#include <gmpxx.h>
+ 
+ #include "Tools/Exceptions.h"
+ #include "Tools/int.h"
+@@ -281,11 +281,7 @@ inline int numBytes(const bigint& m)
+ 
+ inline int probPrime(const bigint& x)
+ {
+-  gmp_randstate_t rand_state;
+-  gmp_randinit_default(rand_state);
+-  int ans = mpz_probable_prime_p(x.get_mpz_t(), rand_state,
+-      max(40, DEFAULT_SECURITY), 0);
+-  gmp_randclear(rand_state);
++  int ans = mpz_probab_prime_p(x.get_mpz_t(), max(40, DEFAULT_SECURITY));
+   return ans;
+ }
+ 
+diff --git a/Math/mpn_fixed.h b/Math/mpn_fixed.h
+index 87e9407..b8f73ef 100644
+--- a/Math/mpn_fixed.h
++++ b/Math/mpn_fixed.h
+@@ -6,7 +6,7 @@
+ #ifndef MATH_MPN_FIXED_H_
+ #define MATH_MPN_FIXED_H_
+ 
+-#include <mpir.h>
++#include <gmp.h>
+ #include <string.h>
+ #include <assert.h>
+ 
+diff --git a/Math/square128.cpp b/Math/square128.cpp
+index fadbe21..7aa2c75 100644
+--- a/Math/square128.cpp
++++ b/Math/square128.cpp
+@@ -3,7 +3,7 @@
+  *
+  */
+ 
+-#include <mpirxx.h>
++#include <gmpxx.h>
+ 
+ #include "OT/BitMatrix.h"
+ #include "Tools/random.h"
+diff --git a/Networking/CryptoPlayer.h b/Networking/CryptoPlayer.h
+index 03c09bf..4d89269 100644
+--- a/Networking/CryptoPlayer.h
++++ b/Networking/CryptoPlayer.h
+@@ -21,7 +21,7 @@
+ class CryptoPlayer : public MultiPlayer<ssl_socket*>
+ {
+     ssl_ctx ctx;
+-    boost::asio::io_service io_service;
++    boost::asio::io_context io_service;
+ 
+     vector<ssl_socket*> other_sockets;
+ 
+diff --git a/Networking/ssl_sockets.h b/Networking/ssl_sockets.h
+index a9ce631..b2d1c26 100644
+--- a/Networking/ssl_sockets.h
++++ b/Networking/ssl_sockets.h
+@@ -18,7 +18,7 @@
+ #define SSL_DIR "Player-Data/"
+ #endif
+ 
+-typedef boost::asio::io_service ssl_service;
++typedef boost::asio::io_context ssl_service;
+ 
+ void check_ssl_file(string filename);
+ void ssl_error(string side, string other, string server);
+@@ -46,7 +46,7 @@ class ssl_socket : public boost::asio::ssl::stream<boost::asio::ip::tcp::socket>
+     typedef boost::asio::ssl::stream<boost::asio::ip::tcp::socket> parent;
+ 
+ public:
+-    ssl_socket(boost::asio::io_service& io_service,
++    ssl_socket(boost::asio::io_context& io_service,
+             boost::asio::ssl::context& ctx, int plaintext_socket, string other,
+             string me, bool client) :
+             parent(io_service, ctx)
+@@ -57,7 +57,7 @@ public:
+ #endif
+         lowest_layer().assign(boost::asio::ip::tcp::v4(), plaintext_socket);
+         set_verify_mode(boost::asio::ssl::verify_peer);
+-        set_verify_callback(boost::asio::ssl::rfc2818_verification(other));
++        set_verify_callback(boost::asio::ssl::host_name_verification(other));
+         if (client)
+             try
+             {
+diff --git a/Tools/random.h b/Tools/random.h
+index 373fcd6..3b16cdb 100644
+--- a/Tools/random.h
++++ b/Tools/random.h
+@@ -7,7 +7,7 @@
+ #include "Tools/avx_memcpy.h"
+ #include "Networking/data.h"
+ 
+-#include <mpir.h>
++#include <gmp.h>
+ 
+ #define USE_AES
+ 

--- a/scripts/lakey/prepare.py
+++ b/scripts/lakey/prepare.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Create bounded-state fixtures from the pinned LaKey REG implementation."""
+import argparse
+import subprocess
+from pathlib import Path
+
+p = argparse.ArgumentParser()
+p.add_argument("upstream", type=Path)
+p.add_argument("--mode", choices=["init", "derive", "refresh"], required=True)
+args = p.parse_args()
+args.log2q, args.stat = 32, 128
+revision = subprocess.check_output(["git", "-C", str(args.upstream), "rev-parse", "HEAD"], text=True).strip()
+if revision != "7a9efcadf134263a94cd0548456e60011a7d4492":
+    p.error("use the pinned LaKey research revision from README.md")
+if args.mode == "init" and any((args.upstream / "Persistence").glob("*.data")):
+    p.error("use a fresh checkout or move existing synthetic Persistence before initialization")
+source = (args.upstream / "Programs/Source/lattice_prf.mpc").read_text()
+source = source.split("def main():")[0]
+source = source.replace("stat = 40 # statistical distance", f"stat = {args.stat} # experiment statistical distance")
+prefix = f'''import os
+program.set_security({args.stat})
+os.environ.update(BASE_RING="GFP", KEYGEN="1", COMPOSE="1", REVEAL="0",
+                  BITS="251", LOG2Q="{args.log2q}", LOG2P="24",
+                  DIM="512", OPTIMIZE="0", DOUBLE="0")
+'''
+body = '''
+from hashlib import shake_256
+from Compiler.library import start_timer, stop_timer
+
+# The request supplies an identity, never an arbitrary matrix.
+def identity_matrix(identity):
+    data = shake_256(b"orbis-lakey-poc-v1\\0" + identity).digest(l*m*4)
+    a = Matrix(l, m, cint)
+    for i in range(l):
+        for j in range(m):
+            off = (i*m+j)*4
+            a[i][j] = int.from_bytes(data[off:off+4], "little") & ((1<<log2q)-1)
+    return a
+'''
+if args.mode == "init":
+    body += '''
+start_timer(1)
+k = Array(m, sint)
+for i in range(m):
+    k[i] = srand()
+k.write_to_file(position=0)
+stop_timer(1)
+print_ln("Master shares initialized; no clear key output")
+'''
+else:
+    body += '''
+k = Array(m, sint)
+k.read_from_file(0)
+'''
+    if args.mode == "refresh":
+        body += '''
+start_timer(2)
+for i in range(m):
+    z = sint.get_random()
+    k[i] = k[i] + z - z.reveal()
+k.write_to_file(position=0)
+stop_timer(2)
+print_ln("Experimental same-committee zero-share refresh; not membership migration")
+'''
+    body += '''
+start_timer(3)
+identities = [b"chain1/ring1/epoch1/named/Alice/amount",
+              b"chain1/ring1/epoch1/named/Bob/amount",
+              b"chain1/ring1/epoch1/named/Alice/sender",
+              b"chain1/ring1/epoch1/general/amount"]
+derived = [eval(identity_matrix(identity), k) for identity in identities]
+stop_timer(3)
+# Fixed four-slot synthetic handoff, removed by the driver after local PRE.
+# This is not production persistent storage of derived shares.
+sint.write_to_file(derived, position=m)
+print_ln("Four transient derived shares written per node; no clear key output")
+'''
+name = f"poc_lakey_{args.mode}"
+path = args.upstream / "Programs/Source" / (name + ".mpc")
+path.write_text(prefix + source + body)
+print(name)


### PR DESCRIPTION
## Motivation

Shieldd audits scan ciphertexts for Alice without knowing beforehand whether they belong to Alice. Today, the result of an authorized Alice scan can also be converted into a result for Bob, even without permission to audit Bob.

The current derivation is `sk_Alice = h(Alice) · s`, where `s` is the master secret and `h(Alice)` is public. For a ciphertext with ephemeral point `R`, the auditor recovers `D_Alice = h(Alice) · s · R`. Knowing Bob’s derivation input lets them compute:

```text
D_Bob = [h(Bob) / h(Alice)] · D_Alice
```

LaKey instead computes `sk_Alice = PRF_s(Alice)` through MPC, and PRE returns `D_Alice = sk_Alice · R`. Bob’s key is a separate pseudorandom output, `sk_Bob = PRF_s(Bob)`: there is no known public ratio to convert Alice’s result into Bob’s. Orbis retains fixed master-share state rather than storing a permanent key share for every user. Encryptors use registered derived public keys.

## This PoC

Demonstrates LaKey-derived Decaf377 shares with existing Orbis encryption and PRE; no production service behavior changes.

- Real five-process MPC and PRE checks pass, including person/field isolation, restart, and share refresh.
- All 32 Decaf377 crypto tests pass.
- Uses synthetic fixtures, not a deployed Orbis service. Production orchestration, authenticated key registration, authorization integration, and cryptographic review remain required.

See [reproduction steps and integration boundaries](scripts/lakey/README.md) for details.
